### PR TITLE
AS#181122346682552, Project Details/Feature Picker: selected features are not being saved

### DIFF
--- a/src/projects/FeatureSelector/DefaultFeatureForm.jsx
+++ b/src/projects/FeatureSelector/DefaultFeatureForm.jsx
@@ -65,7 +65,7 @@ class DefaultFeatureForm extends Component {
             disabled={!isEdittable}
             onChange={ this.toggleFeature }
             name="featue-active"
-            checked={isActive ? 'checked' : null }
+            checked={isActive ? true : false }
           />
         </div>
         <div className="feature-form-content">

--- a/src/projects/FeatureSelector/DefaultFeatureForm.jsx
+++ b/src/projects/FeatureSelector/DefaultFeatureForm.jsx
@@ -65,7 +65,7 @@ class DefaultFeatureForm extends Component {
             disabled={!isEdittable}
             onChange={ this.toggleFeature }
             name="featue-active"
-            checked={isActive ? true : false }
+            checked={isActive}
           />
         </div>
         <div className="feature-form-content">

--- a/src/projects/detail/components/EditProjectForm.jsx
+++ b/src/projects/detail/components/EditProjectForm.jsx
@@ -59,6 +59,9 @@ class EditProjectForm extends Component {
   }
 
   saveFeatures(features) {
+    if (!this.state.project.details.appDefinition) {
+      this.state.project.details.appDefinition = { features: {} }
+    }
     const obj = {
       value: features,
       seeAttached: this.state.project.details.appDefinition.features.seeAttached


### PR DESCRIPTION
-- Fixed

@parthshah can you please review the change? I am not sure if this is the best way to fix this issue. Basically, issue is occurring because the `project.details.appDefinition` is not set if user hasn't saved the project with at least one question answered.