### PR TITLE
Github issue #149 Messaging: empty state for messaging tab

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -43,19 +43,20 @@ const MessageRow = ({title, messages, isActive, unreadCount, onClick}) => {
     </div>
     <div className="message-time">
       {unreadCount > 0 && <div className="badge">{unreadCount}</div>}
-      {!unreadCount && formatTime(lastMessage.date)}
+      {(!unreadCount && lastMessage.date) && formatTime(lastMessage.date)}
     </div>
   </div>)
 }
 
 
-const MessageList = ({threads, onSelect, onAdd, showAddButton}) => (
+const MessageList = ({threads, onSelect, onAdd, showAddButton, showEmptyState}) => (
   <Panel className="message-list">
     <Panel.Title>
       Messages
       { showAddButton && <Panel.AddBtn onClick={onAdd} /> }
     </Panel.Title>
     <div className="panel-messages">
+      { showEmptyState && <MessageRow title="First discussion post" isActive messages={[{ content: ''}]} /> }
       {threads.map((item) => <MessageRow key={item.id} onClick={(e) => onSelect(item, e) } {...item} />)}
     </div>
   </Panel>

--- a/src/components/MessageList/MessagingEmptyState.jsx
+++ b/src/components/MessageList/MessagingEmptyState.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import './MessagingEmptyState.scss'
+import Panel from '../Panel/Panel'
+import ActionCard from '../ActionCard/ActionCard'
+import Comment from '../ActionCard/Comment'
+import { Icons } from 'appirio-tech-react-components'
+
+const MessagingEmptyState = ({ currentUser, onClose }) => (
+  <Panel className="panel-orange action-card messaging-empty-state">
+    <div className="empty-state-content">
+      <a href="javascript:" className="btn-action btn-close" onClick={onClose}>
+        <Icons.CloseIcon />
+      </a>
+      <Comment
+        avatarUrl={ require('../../assets/images/avatar-coder.png') }
+        authorName="Code the Bot"
+        self={false}
+        date=""
+      >
+        Hey {currentUser.firstName}, welcome to the messages section. This is where you can keep communication open and ongoing during the project. You can create new messages from the top left, using the + button. Have in mind that all messages are visible to all team members.
+      </Comment>
+    </div>
+  </Panel>
+)
+
+export default MessagingEmptyState

--- a/src/components/MessageList/MessagingEmptyState.jsx
+++ b/src/components/MessageList/MessagingEmptyState.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import './MessagingEmptyState.scss'
 import Panel from '../Panel/Panel'
-import ActionCard from '../ActionCard/ActionCard'
 import Comment from '../ActionCard/Comment'
 import { Icons } from 'appirio-tech-react-components'
 

--- a/src/components/MessageList/MessagingEmptyState.scss
+++ b/src/components/MessageList/MessagingEmptyState.scss
@@ -1,0 +1,9 @@
+@import "tc-includes";
+
+.messaging-empty-state {
+  .btn-close {
+    fill: $tc-orange-70;
+    top: $base-unit;
+    right: 0px;
+  }
+}

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -51,6 +51,10 @@
       background-color: $tc-white;
       fill: $tc-gray-40;
     }
+
+    .close {
+      
+    }
   }
 }
 .panel.modal-active {
@@ -78,6 +82,9 @@
   &.panel-gray{
     background: $tc-gray-neutral-light;
     margin-bottom: -10px;
+  }
+  &.panel-orange {
+    background-color: $tc-orange-10;
   }
   .panel-body{
     &.active{

--- a/src/projects/detail/Messages.jsx
+++ b/src/projects/detail/Messages.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import MessagesContainer from './containers/MessagesContainer'
 import spinnerWhileLoading from '../../components/LoadingSpinner'
 
+require('./Messages.scss')
+
 // This handles showing a spinner while the state is being loaded async
 const spinner = spinnerWhileLoading(props => !props.isLoading)
 

--- a/src/projects/detail/Messages.scss
+++ b/src/projects/detail/Messages.scss
@@ -1,0 +1,43 @@
+@import "tc-includes";
+// FIXME
+@mixin flexBox {
+  display: flex;
+  flex-direction: row;
+}
+// FIXME
+@mixin flexWidth($number) {
+  -webkit-box-flex: $number;
+  -moz-box-flex: $number;
+  -webkit-flex: $number;
+  -ms-flex: $number;
+  flex: $number;
+}
+
+// FIXME
+.messages-container {
+  @include flexBox;
+  max-width: 1110px;
+  margin: 20px auto;
+  
+  .left-area {
+    @include flexWidth(1);
+    max-width: 360px;
+    z-index: 14;/* Don't know the exact reason, but it needs explicit z-index to get behind the topbar*/
+  }
+  .right-area {
+    @include flexWidth(2);
+    margin-left: 4 * $base-unit;
+
+    .messaging-empty-state {
+      margin-bottom: 4 * $base-unit;
+    }
+
+    .new-post-composer {
+      margin-bottom: 4 * $base-unit;
+    }
+
+    .feed-action-card + .feed-action-card {
+      margin-top: 4 * $base-unit;
+    }
+  }
+}


### PR DESCRIPTION
-- Added empty states for MessageList and right panel of the MessageContainer

@parthshah @fnisen fyi

@parthshah I am having an issue with loading spinner HOC. It seems it renders the target component even before the isLoading is set to false. This is causing empty states to be visible while we are fetching the feeds. Can you please help me out here?