### PR TITLE
Github issue #296 max length validation must be present on Custom Feature title otherwise its showing aligement issue

### DIFF
--- a/src/projects/detail/components/FeatureSelector/CustomFeatureForm.jsx
+++ b/src/projects/detail/components/FeatureSelector/CustomFeatureForm.jsx
@@ -122,6 +122,7 @@ class CustomFeatureForm extends Component {
                 validations="isRequired" required
                 validationError="Feature name is required"
                 wrapperClass="row"
+                maxLength={40}
                 value={ _.get(data, 'title', '') }
               />
             }


### PR DESCRIPTION
-- Fixed by putting maxlength on the input element. However, if we need to inform user about the limit we might want to use validation error rather.