### PR TITLE
Github issue #492 [Team Management] Buttons are not center aligned in assign owner modal

### DIFF
--- a/src/components/TeamManagement/OwnerModal.jsx
+++ b/src/components/TeamManagement/OwnerModal.jsx
@@ -4,11 +4,11 @@ const OwnerModal = ({member, onCancel, onConfirm}) => {
   return (
     <div className="modal">
       <div className="modal-title">
-        Assign member as owner
+        You are about to assign a new project owner
       </div>
       <div className="modal-body">
         <p className="message">
-          This will make <strong>{member.name}</strong> the project owner. Do you still want to proceed?
+          <strong>{member.firstName} {member.lastName}</strong> will become responsible for the project and be able to add and remove team members. Are you sure you want to proceed?
         </p>
 
         <div className="button-area flex center">

--- a/src/components/TeamManagement/TeamManagement.scss
+++ b/src/components/TeamManagement/TeamManagement.scss
@@ -262,6 +262,9 @@ $tc-body-extra-small	: 12px;
       }
       .message {
         margin-bottom: $base-unit*4;
+        strong{
+          @include roboto-bold;
+        }
       }
       .error-message{
         display: block;


### PR DESCRIPTION
-- Fixed copy and missing name in the modal