### PR TITLE
Github issue #395 When user select the "Messages" from the list; posts related to that Message won't see

### DIFF
--- a/src/projects/detail/Messages.scss
+++ b/src/projects/detail/Messages.scss
@@ -18,15 +18,18 @@
   @include flexBox;
   max-width: 1110px;
   margin: 20px auto;
+  height: calc(100% - 20px);// 20px is for bottom margin
   
   .left-area {
     @include flexWidth(1);
     max-width: 360px;
     z-index: 14;/* Don't know the exact reason, but it needs explicit z-index to get behind the topbar*/
+    overflow-y: auto;
   }
   .right-area {
     @include flexWidth(2);
     margin-left: 4 * $base-unit;
+    overflow-y: auto;
 
     .messaging-empty-state {
       margin-bottom: 4 * $base-unit;

--- a/src/projects/detail/containers/MessagesContainer.js
+++ b/src/projects/detail/containers/MessagesContainer.js
@@ -7,7 +7,6 @@ import MessagingEmptyState from '../../../components/MessageList/MessagingEmptyS
 import MessageDetails from '../../../components/MessageDetails/MessageDetails'
 import NewPost from '../../../components/Feed/NewPost'
 import { laodProjectMessages, createProjectTopic, loadFeedComments, addFeedComment } from '../../actions/projectTopics'
-import Sticky from 'react-stickynode'
 import spinnerWhileLoading from '../../../components/LoadingSpinner'
 import {FullHeightContainer} from 'appirio-tech-react-components'
 

--- a/src/projects/detail/containers/MessagesContainer.js
+++ b/src/projects/detail/containers/MessagesContainer.js
@@ -9,6 +9,7 @@ import NewPost from '../../../components/Feed/NewPost'
 import { laodProjectMessages, createProjectTopic, loadFeedComments, addFeedComment } from '../../actions/projectTopics'
 import Sticky from 'react-stickynode'
 import spinnerWhileLoading from '../../../components/LoadingSpinner'
+import {FullHeightContainer} from 'appirio-tech-react-components'
 
 import {
   THREAD_MESSAGES_PAGE_SIZE,
@@ -219,28 +220,28 @@ class MessagesView extends React.Component {
     }
 
     return (
-      <div className="messages-container">
-        <div className="left-area">
-          <Sticky top={80}>
-            <MessageList
-              onAdd={() => this.setState({isCreateNewMessage: true})}
-              threads={threads}
-              onSelect={this.onThreadSelect}
-              showAddButton={ !!currentMemberRole }
-              showEmptyState={ showEmptyState && !threads.length }
-            />
-          </Sticky>
+      <FullHeightContainer offset={80}>
+        <div className="messages-container">
+            <div className="left-area">
+              <MessageList
+                onAdd={() => this.setState({isCreateNewMessage: true})}
+                threads={threads}
+                onSelect={this.onThreadSelect}
+                showAddButton={ !!currentMemberRole }
+                showEmptyState={ showEmptyState && !threads.length }
+              />
+            </div>
+            <div className="right-area">
+              { (showEmptyState && !threads.length) &&
+                <MessagingEmptyState
+                  currentUser={currentUser}
+                  onClose={() => this.setState({showEmptyState: false})}
+                />
+              }
+              { renderRightPanel() }
+            </div>
         </div>
-        <div className="right-area">
-          { (showEmptyState && !threads.length) &&
-            <MessagingEmptyState
-              currentUser={currentUser}
-              onClose={() => this.setState({showEmptyState: false})}
-            />
-          }
-          { renderRightPanel() }
-        </div>
-      </div>
+      </FullHeightContainer>
     )
   }
 }

--- a/src/projects/detail/containers/MessagesContainer.js
+++ b/src/projects/detail/containers/MessagesContainer.js
@@ -219,7 +219,7 @@ class MessagesView extends React.Component {
     }
 
     return (
-      <FullHeightContainer offset={80}>
+      <FullHeightContainer offset={ 80 }>
         <div className="messages-container">
             <div className="left-area">
               <MessageList


### PR DESCRIPTION
-- Wrapped message container into full height container. Also had to remove the sticky behaviour to not have overflow issue when page is scrolled to the bottom. And, I guess, in after scrolls bar we don't need sticky behaviour anyway.

@vic-appirio Please let me know if you think we have non javascript solution for this.