### PR TITLE
Github issue #287 after applying search if click on Connect logo, should lands user to project listing page

### DIFF
--- a/src/components/TopBar/TopBar.jsx
+++ b/src/components/TopBar/TopBar.jsx
@@ -66,7 +66,7 @@ class TopBar extends Component {
     ]
     const logo = (
       <div className="logo-wrapper">
-        <Link className="logo" to={logoTargetUrl}><ConnectLogoBeta /></Link>
+        <Link className="logo" to={logoTargetUrl} target="_self"><ConnectLogoBeta /></Link>
       </div>
     )
     const avatar = (


### PR DESCRIPTION
-- Fixed. Now it reloads the page even if user is already on project listing page.