### PR TITLE
Github issue #526 Add Team Member || Modal is not visible after clicking on Add button

### DIFF
--- a/src/components/TeamManagement/AddTeamMember.jsx
+++ b/src/components/TeamManagement/AddTeamMember.jsx
@@ -3,7 +3,7 @@ import AutoCompleteInput from './AutoCompleteInput'
 import cn from 'classnames'
 import { Icons } from 'appirio-tech-react-components'
 import { PROJECT_ROLE_CUSTOMER } from '../../config/constants'
-
+import Scroll from 'react-scroll'
 
 const { XMarkIcon } = Icons
 
@@ -17,6 +17,7 @@ const AddTeamMember = (props) => {
   const onBtnClose = () => {
     onKeywordChange('')
     onToggleAddTeamMember(false)
+    Scroll.animateScroll.scrollMore(1)
   }
   const onConfirmAddMember = () => {
     // if adding a customer and there is no owner yet for the project

--- a/src/components/TeamManagement/AutoCompleteInput.jsx
+++ b/src/components/TeamManagement/AutoCompleteInput.jsx
@@ -63,6 +63,7 @@ class AutoCompleteInput extends React.Component {
           {selectedNewMember && <img src={selectedNewMember.photoURL} />}
         </span>
         <input
+          autoFocus
           ref="input"
           value={keyword}
           className="tc-file-field__inputs"


### PR DESCRIPTION
-- Applied fix from winner of the challenge. This fix has least intrusive changes with only two files being changed and only 3 lines of addition overall. Other change which I committed in separate branch ([feature/add_team_member_scroll](https://github.com/appirio-tech/connect-app/commit/f83c2aedd173701c8f1381092890d7e3afb28523)) works fine but has changes in more 6-7 files and requires functional component to be stateful. So, we are going to accept this fix as final solution.