### PR TITLE
Github issue #527, Discussions: Discussion thread not showing all posts

### DIFF
--- a/src/projects/actions/projectTopics.js
+++ b/src/projects/actions/projectTopics.js
@@ -62,7 +62,7 @@ const getTopicsWithComments = (projectId, tag) => {
       return Promise.all(additionalPosts)
         .then(postArr => {
           _.forEach(postArr, (p) => {
-            const topic = _.find(topics, t => p.topicId)
+            const topic = _.find(topics, t => t.id === p.topicId)
             topic.posts = _.sortBy(topic.posts.concat(p.posts), ['id'])
           })
           return { topics, totalCount }


### PR DESCRIPTION
-- Found critical issue when reviewing the code the mentioned issue. It was causing wrong posts to be shown under a topic.