### PR TITLE
Github issue #552, Project listing: return user to previous spot in listing after back from project

### DIFF
--- a/src/projects/list/components/Projects/Projects.jsx
+++ b/src/projects/list/components/Projects/Projects.jsx
@@ -15,7 +15,7 @@ class Projects extends Component {
   }
 
   componentDidUpdate() {
-      window.scrollTo(0, parseInt(window.sessionStorage.getItem("projectsPageScrollTop")));
+    window.scrollTo(0, parseInt(window.sessionStorage.getItem("projectsPageScrollTop")));
   }
 
   componentWillUnmount(){
@@ -45,6 +45,7 @@ class Projects extends Component {
   }
 
   onPageChange(pageNum) {
+    window.sessionStorage.removeItem('projectsPageScrollTop');
     this.routeWithParams(this.props.criteria, pageNum)
   }
 


### PR DESCRIPTION
-- Fixed the case where scroll position was being maintained even in case of user moving between different pages of the project listing.