### PR TITLE
Github issue #566, Connect Login/Logout redirect not working correctly in Safari

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -180,8 +180,8 @@ export const PROJECT_ATTACHMENTS_FOLDER = process.env.PROJECT_ATTACHMENTS_FOLDER
 export const DOMAIN = process.env.domain || 'topcoder.com'
 export const CONNECT_DOMAIN = `connect.${DOMAIN}`
 export const ACCOUNTS_APP_CONNECTOR_URL = process.env.ACCOUNTS_APP_CONNECTOR_URL
-export const ACCOUNTS_APP_LOGIN_URL = `https://accounts.${DOMAIN}/connect`
-export const ACCOUNTS_APP_REGISTER_URL = `https://accounts.${DOMAIN}/connect/registration`
+export const ACCOUNTS_APP_LOGIN_URL = `https://accounts.${DOMAIN}/#/connect`
+export const ACCOUNTS_APP_REGISTER_URL = `https://accounts.${DOMAIN}/#/connect/registration`
 
 export const TC_API_URL = `https://api.${DOMAIN}`
 export const DIRECT_PROJECT_URL = `https://www.${DOMAIN}/direct/projectOverview?formData.projectId=`


### PR DESCRIPTION
-- Fixed. Reason was the missing # in URL. # is required for angular routes.