### PR TITLE
Updating footer Help link

### DIFF
--- a/src/components/FooterV2/FooterV2.jsx
+++ b/src/components/FooterV2/FooterV2.jsx
@@ -6,7 +6,7 @@ const FooterV2 = () => (
     <ul className="footer-links">
       <li><a href="https://www.topcoder.com/about-topcoder/" target="_blank">About</a></li>
       <li><a href="https://www.topcoder.com/about-topcoder/contact/" target="_blank">Contact</a></li>
-      <li><a href="https://help.topcoder.com/hc/en-us" target="_blank">Help</a></li>
+      <li><a href="https://help.topcoder.com/hc/en-us/articles/225540188-Topcoder-Connect-FAQs" target="_blank">Help</a></li>
       <li><a href="https://www.topcoder.com/community/how-it-works/privacy-policy/" target="_blank">Privacy</a></li>
       <li><a href="https://connect.topcoder.com/terms">Terms</a></li>
     </ul>


### PR DESCRIPTION
Updating footer Help link to point to Help Center FAQ instead of general help page