### PR TITLE
Github issue#587, Comments Sort order within a topic is incorrect

### DIFF
--- a/src/projects/reducers/projectTopics.js
+++ b/src/projects/reducers/projectTopics.js
@@ -157,6 +157,7 @@ export const projectTopics = function (state=initialState, action) {
         posts: { $push: payload.posts },
         isLoadingComments: { $set : false }
       })
+      updatedFeed.posts = _.sortBy(updatedFeed.posts, ['id'])
       const feedUpdateQuery = {}
       feedUpdateQuery[tag] = { topics: { $splice: [[feedIndex, 1, updatedFeed]] } }
       // update the state


### PR DESCRIPTION
-- Fixed. We were missing sorting the posts when loading more posts for a feed

@parthshah fyi