### PR TITLE
Github issue#629, Allow Managers to delete newly created projects

### DIFF
--- a/src/projects/detail/containers/ProjectInfoContainer.js
+++ b/src/projects/detail/containers/ProjectInfoContainer.js
@@ -123,7 +123,8 @@ class ProjectInfoContainer extends React.Component {
       directLinks.push({name: 'Salesforce Lead', href: `${SALESFORCE_PROJECT_LEAD_LINK}${project.id}`})
     }
 
-    const canDeleteProject = currentMemberRole === PROJECT_ROLE_OWNER
+    const canDeleteProject =
+      (currentMemberRole === PROJECT_ROLE_OWNER || currentMemberRole === PROJECT_ROLE_MANAGER)
       && project.status === 'draft'
     return (
       <div>


### PR DESCRIPTION
-- Added Project Manager role to the allowed roles for deleting a project in draft mode.

fyi @fnisen 