### PR TITLE
Github issue #663, Fallback spec template is not working for generic …

### DIFF
--- a/src/config/projectSpecification/typeToSpecification.json
+++ b/src/config/projectSpecification/typeToSpecification.json
@@ -1,5 +1,6 @@
 {
 	"visual_design": "avd.v1.0",
 	"visual_prototype": "topcoder.v2.0",
-	"app_dev": "topcoder.v2.0"
+	"app_dev": "topcoder.v2.0",
+  "generic": "topcoder.v2.0"
 }


### PR DESCRIPTION
-- Added mapping for generic project type to spec version