### PR TITLE
Remove the 'screens' heading from Screens section

### DIFF
--- a/src/config/projectQuestions/avd.v1.0.js
+++ b/src/config/projectQuestions/avd.v1.0.js
@@ -127,6 +127,7 @@ const sections = [
         required: true,
         fieldName: 'details.appScreens.screens',
         title: 'Screens',
+        hideTitle: true,
         description: 'Add any other important information regarding your project (e.g., links to documents or existing applications, budget or timeing constraints)',
         type: 'screens',
         questions: [

--- a/src/projects/detail/components/SpecSection.jsx
+++ b/src/projects/detail/components/SpecSection.jsx
@@ -12,9 +12,12 @@ const SpecSection = props => {
   console.log('SpecSection', props)
   const renderSubSection = (subSection, idx) => (
     <div key={idx} className="section-features-module" id={[id, subSection.id].join('-')}>
-      <div className="sub-title">
-        <h4 className="title">{typeof subSection.title === 'function' ? subSection.title(project): subSection.title } <span>*</span></h4>
-      </div>
+      {
+        subSection.hideTitle ? null :
+        <div className="sub-title">
+          <h4 className="title">{typeof subSection.title === 'function' ? subSection.title(project): subSection.title } <span>*</span></h4>
+        </div>
+      }
       <div className="content-boxs">
         {renderChild(subSection)}
       </div>

--- a/src/projects/detail/components/SpecSection.jsx
+++ b/src/projects/detail/components/SpecSection.jsx
@@ -13,7 +13,7 @@ const SpecSection = props => {
   const renderSubSection = (subSection, idx) => (
     <div key={idx} className="section-features-module" id={[id, subSection.id].join('-')}>
       {
-        subSection.hideTitle ? null :
+        !subSection.hideTitle &&
         <div className="sub-title">
           <h4 className="title">{typeof subSection.title === 'function' ? subSection.title(project): subSection.title } <span>*</span></h4>
         </div>


### PR DESCRIPTION
Related issue: #680 
This is a generic solution (not just for the screens section).

Now if you add the `hideTitle: true` to any `subSections` in `/src/config/projectQuestions/avd.v1.0.js` the heading won't be rendered.