### PR TITLE
Make all textareas in project specification autoresizable

### DIFF
--- a/src/projects/detail/components/EditProjectForm.jsx
+++ b/src/projects/detail/components/EditProjectForm.jsx
@@ -36,13 +36,13 @@ class EditProjectForm extends Component {
     let updatedProject = Object.assign({}, nextProps.project)
     if (this.state.isFeaturesDirty && !this.state.isSaving) {
       updatedProject = update(updatedProject, {
-        details: { 
-          appDefinition: { 
-            features: { 
-              $set: this.state.project.details.appDefinition.features 
-            } 
-          } 
-        } 
+        details: {
+          appDefinition: {
+            features: {
+              $set: this.state.project.details.appDefinition.features
+            }
+          }
+        }
       })
     }
     this.setState({
@@ -163,7 +163,7 @@ class EditProjectForm extends Component {
             isEdittable={isEdittable} onSave={ this.saveFeatures }
           />
           <div onClick={ this.hideFeaturesDialog } className="feature-selection-dialog-close">
-            Save and close <Icons.XMarkIcon />  
+            Save and close <Icons.XMarkIcon />
           </div>
         </Modal>
       </div>

--- a/src/projects/detail/components/SpecQuestions.jsx
+++ b/src/projects/detail/components/SpecQuestions.jsx
@@ -44,6 +44,7 @@ const SpecQuestions = ({questions, project, resetFeatures, showFeaturesDialog}) 
     case 'see-attached-textbox':
       ChildElem = SeeAttachedTextareaInput
       elemProps.wrapperClass = 'row'
+      elemProps.autoResize = true
       // child = <SeeAttachedTextareaInput name={q.fieldName} label={q.label} value={value} wrapperClass="row" />
       break
     case 'textinput':
@@ -55,6 +56,7 @@ const SpecQuestions = ({questions, project, resetFeatures, showFeaturesDialog}) 
     case 'textbox':
       ChildElem = TCFormFields.Textarea
       elemProps.wrapperClass = 'row'
+      elemProps.autoResize = true
       // child = <TCFormFields.Textarea name={q.fieldName} label={q.label} value={value} wrapperClass="row" />
       break
     case 'radio-group':

--- a/src/projects/detail/components/SpecScreenQuestions.jsx
+++ b/src/projects/detail/components/SpecScreenQuestions.jsx
@@ -37,6 +37,7 @@ const SpecScreenQuestions = ({questions, screen}) => {
     case 'textbox':
       ChildElem = TCFormFields.Textarea
       elemProps.wrapperClass = 'row'
+      elemProps.autoResize = true
       break
     case 'radio-group':
       ChildElem = TCFormFields.RadioGroup

--- a/src/projects/detail/components/SpecSection.jsx
+++ b/src/projects/detail/components/SpecSection.jsx
@@ -53,6 +53,7 @@ const SpecSection = props => {
             {props.description}
           </div>
           <TCFormFields.Textarea
+            autoResize={true}
             name={props.fieldName}
             value={_.get(project, props.fieldName) || ''}
           />


### PR DESCRIPTION
Related issue: #628 
To test it you have to either merge this https://github.com/appirio-tech/react-components/pull/124 PR in the `react-components` repo or modify the package.json so the `appirio-tech-react-components` is fetched from `ThomasKranitsas/react-components.git#autoresize-textarea`