### PR TITLE
Fix screen limit after defining some screens

### DIFF
--- a/src/projects/detail/components/SpecQuestions.jsx
+++ b/src/projects/detail/components/SpecQuestions.jsx
@@ -39,6 +39,20 @@ const SpecQuestions = ({questions, project, resetFeatures, showFeaturesDialog}) 
       label: q.label,
       value: _.get(project, q.fieldName, undefined)
     }
+
+    if (q.fieldName === 'details.appDefinition.numberScreens') {
+      _.each(q.options, (option) => {
+        option.disabled = parseInt(option.value) < project.details.appScreens.screens.length
+        option.errorMessage = (
+          <p>
+            You've defined more than {option.value} screens.
+            <br/>
+            Please delete screens to select this option.
+          </p>
+        )
+      })
+    }
+
     let ChildElem = ''
     switch (q.type) {
     case 'see-attached-textbox':


### PR DESCRIPTION
Related issue: #639 

@gondzo I've submitted a PR on the `react-components` repo.
To test changes on this repo you can simple modify the package.json to fetch react-components from `ThomasKranitsas/react-components.git#update-tileradiogroup`

Note that the disabled/enabled options are updated after you click the `Save changes` button. I discuss this with @fnisen on slack and we decided to change the functionality to update disabled/enabled options when adding/removing screens after we merge both this PR & https://github.com/appirio-tech/connect-app/pull/666 otherwise we'll get conflicts.

Ref: https://github.com/appirio-tech/react-components/pull/126