### PR TITLE
Fix missing * form manatory fields of type 'questions'

### DIFF
--- a/src/components/ProjectStatus/ProjectStatusChangeConfirmation.jsx
+++ b/src/components/ProjectStatus/ProjectStatusChangeConfirmation.jsx
@@ -45,7 +45,7 @@ const ProjectStatusChangeConfirmation = ({ newStatus, onCancel, onConfirm, onRea
               <SelectDropdown
                 options={ cancelReasons }
                 onSelect={ onReasonUpdate }
-                theme='default'
+                theme="default"
               />
             </div>
           </div>

--- a/src/components/ProjectType/ProjectType.jsx
+++ b/src/components/ProjectType/ProjectType.jsx
@@ -16,7 +16,7 @@ const deviceMap = {
 /*eslint-disable camelcase */
 const typeMap = {
   app_dev: 'Design & Development Project',
-  generic: 'Work Project',// needed for backward compatibility with templates < v1.1
+  generic: 'Work Project', // needed for backward compatibility with templates < v1.1
   visual_design: 'Visual Design Project',
   visual_prototype: 'Visual Prototype Project'// needed for backward compatibility with templates < v1.1
 }

--- a/src/config/projectWizard/index.js
+++ b/src/config/projectWizard/index.js
@@ -25,7 +25,7 @@ export default {
       },
       'Other Design': {
         brief: 'other designs',
-        details: `Get help with other types of design`,
+        details: 'Get help with other types of design',
         icon: 'project-wireframes',
         id: 'generic_design'
       }
@@ -39,7 +39,7 @@ export default {
     subtypes: {
       Prototype: {
         brief: '3-20 screens',
-        details: `Translate designs to an HTML/CSS/JavaScript prototype`,
+        details: 'Translate designs to an HTML/CSS/JavaScript prototype',
         icon: 'project-prototype-demo',
         id: 'visual_prototype'
       },
@@ -51,7 +51,7 @@ export default {
       },
       'Application Development': {
         brief: 'Apps',
-        details: `Build apps for mobile, web, or wearables`,
+        details: 'Build apps for mobile, web, or wearables',
         icon: 'project-development-code',
         id: 'application_development'
       },

--- a/src/projects/detail/components/SpecQuestions.jsx
+++ b/src/projects/detail/components/SpecQuestions.jsx
@@ -29,7 +29,7 @@ const getIcon = icon => {
   }
 }
 
-const SpecQuestions = ({questions, project, resetFeatures, showFeaturesDialog}) => {
+const SpecQuestions = ({questions, project, resetFeatures, showFeaturesDialog, isRequired}) => {
 
   const renderQ = (q, index) => {
     // let child = null
@@ -125,7 +125,7 @@ const SpecQuestions = ({questions, project, resetFeatures, showFeaturesDialog}) 
         title={q.title}
         icon={getIcon(q.icon)}
         description={q.description}
-        required={q.required}
+        required={isRequired}
       >
         <ChildElem {...elemProps} />
       </SpecQuestionList.Item>

--- a/src/projects/detail/components/SpecSection.jsx
+++ b/src/projects/detail/components/SpecSection.jsx
@@ -25,7 +25,10 @@ const SpecSection = props => {
       {
         !subSection.hideTitle &&
         <div className="sub-title">
-          <h4 className="title">{typeof subSection.title === 'function' ? subSection.title(project): subSection.title } <span>*</span></h4>
+          <h4 className="title">
+            {typeof subSection.title === 'function' ? subSection.title(project): subSection.title }
+            {subSection.isRequired && <span>*</span>}
+          </h4>
         </div>
       }
       <div className="content-boxs">
@@ -37,7 +40,7 @@ const SpecSection = props => {
   const onValidate = (isInvalid) => validate(isInvalid)
 
   const renderChild = props => {
-    const {type} = props
+    const {type, required} = props
     switch(type) {
     case 'tabs': {
       const tabs = _.get(props, 'tabs')
@@ -59,6 +62,7 @@ const SpecSection = props => {
           resetFeatures={resetFeatures}
           questions={props.questions}
           project={project}
+          isRequired={props.required}
         />
       )
     case 'notes':

--- a/src/projects/detail/components/SpecSection.jsx
+++ b/src/projects/detail/components/SpecSection.jsx
@@ -40,7 +40,7 @@ const SpecSection = props => {
   const onValidate = (isInvalid) => validate(isInvalid)
 
   const renderChild = props => {
-    const {type, required} = props
+    const {type} = props
     switch(type) {
     case 'tabs': {
       const tabs = _.get(props, 'tabs')
@@ -72,7 +72,7 @@ const SpecSection = props => {
             {props.description}
           </div>
           <TCFormFields.Textarea
-            autoResize={true}
+            autoResize
             name={props.fieldName}
             value={_.get(project, props.fieldName) || ''}
           />

--- a/src/projects/detail/components/VisualDesignProjectEstimateSection.jsx
+++ b/src/projects/detail/components/VisualDesignProjectEstimateSection.jsx
@@ -3,7 +3,7 @@ import './VisualDesignProjectEstimateSection.scss'
 import typeToSpecification from '../../../config/projectSpecification/typeToSpecification'
 import _ from 'lodash'
 
-const numberWithCommas = (n) => n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+const numberWithCommas = (n) => n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 const DEFAULT_AVD_TEMPLATE = 'avd.v1.1'
 
 const VisualDesignProjectEstimateSection = ({products, numberScreens}) => {


### PR DESCRIPTION
Issue #640

The issue was that the `*` was only rendered on the title of each `required` subSection.
So when a subSection is `type: 'questions'` then the `*` is only rendered on the subSection title and not on each question title.