### PR TITLE
Fixed #696 Project Name should be focused immediately after rendering the project creation form

### DIFF
--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -10,6 +10,7 @@ function TextInput(props) {
       placeholder={props.placeholder}
       type="text"
       value={props.value}
+      autoFocus={props.autoFocus}
     />
   )
 }

--- a/src/projects/create/components/WizardHeader.jsx
+++ b/src/projects/create/components/WizardHeader.jsx
@@ -18,6 +18,7 @@ function WizardHeader(props) {
         onChange={props.onProjectNameChange}
         placeholder="Enter project name here"
         value={props.projectName}
+        autoFocus
       />
       <div className="project-ref-code-wrapper">
         <TextInput


### PR DESCRIPTION
Issue #696