### PR TITLE
Github issue#691, Refresh Project Estimate component on change of number of screens

### DIFF
--- a/src/projects/detail/components/EditProjectForm.jsx
+++ b/src/projects/detail/components/EditProjectForm.jsx
@@ -135,10 +135,15 @@ class EditProjectForm extends Component {
     this.props.submitHandler(model)
   }
 
-  handleChange(change, isChanged) {
-    if (isChanged) {
-      this.props.fireProjectDirty(change)
-    }
+  /**
+   * Handles the change event of the form.
+   *
+   * @param change changed form model in flattened form
+   * @param isChanged flag that indicates if form actually changed from initial model values
+   */
+  handleChange(change) {
+    // removed check for isChanged argument to fire the PROJECT_DIRTY event for every change in the form
+    this.props.fireProjectDirty(change)
   }
 
 


### PR DESCRIPTION
-- Fired PROJECT_DIRTY action for every change event fired by the form. Earlier it was firing the PROJECT_DIRTY action only if the form has actually changed its model from the original value.