### PR TITLE
Github issue#1037, Project spec information is not saved when changing project types

### DIFF
--- a/src/config/projectWizard/index.js
+++ b/src/config/projectWizard/index.js
@@ -1,3 +1,6 @@
+import _ from 'lodash'
+import typeToSpecification from '../projectSpecification/typeToSpecification'
+
 const products = {
   Design: {
     icon: 'product-app-visual-design',
@@ -107,3 +110,32 @@ export function findProductCategory(product) {
     }
   }
 }
+
+/**
+ * Finds field from the project creation template
+ *
+ * @param {string} product      id of the product. It should resolve to a template where search is to be made.
+ * @param {string} sectionId    id of the section in the product template
+ * @param {string} subSectionId id of the sub section under the section identified by sectionId
+ * @param {string} fieldName    name of the field to be fetched
+ *
+ * @return {object} field from the template, if found, null otherwise
+ */
+export function getProjectCreationTemplateField(product, sectionId, subSectionId, fieldName) {
+    let specification = 'topcoder.v1'
+    if (product)
+      specification = typeToSpecification[product]
+    let sections = require(`../projectQuestions/${specification}`).basicSections
+    const section = _.find(sections, {id: sectionId})
+    let subSection = null
+    if (subSectionId && section) {
+      subSection = _.find(section.subSections, {id : subSectionId })
+    }
+    if (subSection) {
+      if (subSectionId === 'questions') {
+        return _.find(subSection.questions, { fieldName })
+      }
+      return subSection.fieldName === fieldName ? subSection : null
+    }
+    return null
+  }

--- a/src/config/projectWizard/index.js
+++ b/src/config/projectWizard/index.js
@@ -125,7 +125,7 @@ export function getProjectCreationTemplateField(product, sectionId, subSectionId
     let specification = 'topcoder.v1'
     if (product)
       specification = typeToSpecification[product]
-    let sections = require(`../projectQuestions/${specification}`).basicSections
+    const sections = require(`../projectQuestions/${specification}`).basicSections
     const section = _.find(sections, {id: sectionId})
     let subSection = null
     if (subSectionId && section) {

--- a/src/projects/create/components/ProjectWizard.jsx
+++ b/src/projects/create/components/ProjectWizard.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import { unflatten } from 'flat'
 import React, { Component, PropTypes } from 'react'
 
-import config, { findProductCategory } from '../../../config/projectWizard'
+import config, { findProductCategory, getProjectCreationTemplateField } from '../../../config/projectWizard'
 import Wizard from '../../../components/Wizard'
 import SelectProduct from './SelectProduct'
 import IncompleteProjectConfirmation from './IncompleteProjectConfirmation'
@@ -155,7 +155,7 @@ class ProjectWizard extends Component {
     const updateQuery = { }
     const detailsQuery = { products : [product] }
     // restore common fields from dirty project
-    this.restoreCommonDetails(updateQuery, detailsQuery)
+    this.restoreCommonDetails(product, updateQuery, detailsQuery)
     updateQuery.details = { $set : detailsQuery}
     if (projectType) {
       updateQuery.type = {$set : projectType }
@@ -175,7 +175,7 @@ class ProjectWizard extends Component {
    * 
    * Added for Github issue#1037
    */
-  restoreCommonDetails(updateQuery, detailsQuery) {
+  restoreCommonDetails(updatedProduct, updateQuery, detailsQuery) {
     const name = _.get(this.state.dirtyProject, 'name')
     // if name was already entered, restore it
     if (name) {
@@ -191,6 +191,32 @@ class ProjectWizard extends Component {
     if (utm) {
       detailsQuery.utm = { code : utm.code }
     }
+    const appDefinitionQuery = {}
+    const goal = _.get(this.state.dirtyProject, 'details.appDefinition.goal')
+    // finds the goal field from the updated product template
+    const goalField = getProjectCreationTemplateField(
+      updatedProduct,
+      'appDefinition',
+      'questions',
+      'details.appDefinition.goal.value'
+    )
+    // if goal was already entered and updated product template has the field, restore it
+    if (goalField && goal) {
+      appDefinitionQuery.goal = goal
+    }
+    const users = _.get(this.state.dirtyProject, 'details.appDefinition.users')
+    // finds the users field from the target product template
+    const usersField = getProjectCreationTemplateField(
+      updatedProduct,
+      'appDefinition',
+      'questions',
+      'details.appDefinition.users.value'
+    )
+    // if users was already entered and updated product template has the field, restore it
+    if (usersField && users) {
+      appDefinitionQuery.users = users
+    }
+    detailsQuery.appDefinition = appDefinitionQuery
   }
 
   handleProjectChange(change) {


### PR DESCRIPTION
— copying goal and users fields as well when user changes the product type.
— it now validates, before copying, if the target product template contains the fields being copied.