### PR TITLE
Github issue#1125, Do not show section number when there is only one section

### DIFF
--- a/src/projects/detail/components/SidebarNav.jsx
+++ b/src/projects/detail/components/SidebarNav.jsx
@@ -1,6 +1,7 @@
 
 import React, { Component, PropTypes } from 'react'
 import { Link as DirectLink } from 'react-scroll'
+import cn from 'classnames'
 import { Icons } from 'appirio-tech-react-components'
 
 require('./SidebarNav.scss')
@@ -39,7 +40,7 @@ const SidebarNavItem = ({ name, link, required, subItems, index}) =>
   <div className="item">
     <DirectLink to={link} {...scrollProps} href="javascript:">
       <h4 className="title">
-        <span className="number">{index}.</span>{name}
+        <span className="number" >{index}.</span>{name}
           {required && <span className="required">* required</span>}
       </h4>
     </DirectLink>
@@ -59,7 +60,7 @@ class SidebarNav extends Component {
       )
     }
     return (
-      <div className="list-group">
+      <div className={cn('list-group', {'single-section' : items.length === 1})}>
         {items.map(renderChild)}
       </div>
     )

--- a/src/projects/detail/components/SidebarNav.scss
+++ b/src/projects/detail/components/SidebarNav.scss
@@ -81,4 +81,18 @@
       }
     }
   }
+
+  &.single-section {
+    .title {
+      padding-left: 0px;
+
+      .number {
+        display: none;
+      }
+    }
+
+    .boxs {
+      padding-left: 20px;// 42 - 22
+    }
+  }
 }


### PR DESCRIPTION
— Not rendering the number for single section template
— Fixed padding of sub sections of the section in such cases