### PR TITLE
Feature/sync url change for logged in user

### DIFF
--- a/src/components/TopBar/ProjectsToolBar.js
+++ b/src/components/TopBar/ProjectsToolBar.js
@@ -8,15 +8,11 @@ import _ from 'lodash'
 import { SearchBar } from 'appirio-tech-react-components'
 import Filters from './Filters'
 
-import SVGIconImage from '../SVGIconImage'
-import CoderBot from '../CoderBot/CoderBot'
-
 import { projectSuggestions, loadProjects } from '../../projects/actions/loadProjects'
 import {
   ROLE_CONNECT_COPILOT,
   ROLE_CONNECT_MANAGER,
-  ROLE_ADMINISTRATOR,
-  PROJECT_STATUS_IN_REVIEW
+  ROLE_ADMINISTRATOR
 } from '../../config/constants'
 
 
@@ -141,7 +137,7 @@ class ProjectsToolBar extends Component {
 
   render() {
     const { logo, userMenu, userRoles, criteria, isPowerUser } = this.props
-    const { errorCreatingProject, isFilterVisible } = this.state
+    const { isFilterVisible } = this.state
     const isLoggedIn = userRoles && userRoles.length
 
     const noOfFilters = _.keys(criteria).length - 1 // -1 for default sort criteria

--- a/src/components/TopBar/ProjectsToolBar.js
+++ b/src/components/TopBar/ProjectsToolBar.js
@@ -1,19 +1,16 @@
 require('./ProjectsToolBar.scss')
 
 import React, {PropTypes, Component} from 'react'
+import { Link } from 'react-router'
 import { connect } from 'react-redux'
 import cn from 'classnames'
 import _ from 'lodash'
-import Modal from 'react-modal'
 import { SearchBar } from 'appirio-tech-react-components'
 import Filters from './Filters'
 
-import ModalControl from '../ModalControl'
 import SVGIconImage from '../SVGIconImage'
 import CoderBot from '../CoderBot/CoderBot'
-import ProjectWizard from '../../projects/create/components/ProjectWizard'
 
-import { createProjectWithStatus as createProjectAction } from '../../projects/actions/project'
 import { projectSuggestions, loadProjects } from '../../projects/actions/loadProjects'
 import {
   ROLE_CONNECT_COPILOT,
@@ -28,18 +25,14 @@ class ProjectsToolBar extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isCreateProjectModalVisible : false,
       errorCreatingProject: false,
       isFilterVisible: false
     }
     this.applyFilters = this.applyFilters.bind(this)
     this.toggleFilter = this.toggleFilter.bind(this)
-    this.showCreateProjectDialog = this.showCreateProjectDialog.bind(this)
-    this.hideCreateProjectDialog = this.hideCreateProjectDialog.bind(this)
     this.handleTermChange = this.handleTermChange.bind(this)
     this.handleSearch = this.handleSearch.bind(this)
     this.handleMyProjectsFilter = this.handleMyProjectsFilter.bind(this)
-    this.createProject = this.createProject.bind(this)
     this.onLeave = this.onLeave.bind(this)
   }
 
@@ -51,7 +44,6 @@ class ProjectsToolBar extends Component {
         this.setState({
           isProjectDirty : false
         }, () => {
-          this.hideCreateProjectDialog()
           this.props.router.push('/projects/' + nextProps.project.id)
         })
       } else {
@@ -103,26 +95,6 @@ class ProjectsToolBar extends Component {
     this.applyFilters({memberOnly: event.target.checked})
   }
 
-  showCreateProjectDialog() {
-    this.setState({
-      isCreateProjectModalVisible : true
-    })
-  }
-
-  hideCreateProjectDialog() {
-    let confirm = true
-    if (this.state.isProjectDirty) {
-      confirm = window.confirm('You have unsaved changes. Are you sure you want to leave?')
-    }
-    if (confirm === true) {
-      this.setState({
-        isProjectDirty: false,
-        isCreateProjectModalVisible : false,
-        errorCreatingProject: false
-      })
-    }
-  }
-
   applyFilters(filter) {
     const criteria = _.assign({}, this.props.criteria, filter)
     if (criteria && criteria.keyword) {
@@ -155,62 +127,27 @@ class ProjectsToolBar extends Component {
     this.props.loadProjects(criteria, page)
   }
 
-  createProject(project) {
-    this.props.createProjectAction(project, PROJECT_STATUS_IN_REVIEW)
-  }
-
   shouldComponentUpdate(nextProps, nextState) {
     const { user, criteria, creatingProject, projectCreationError, searchTermTag } = this.props
-    const { isCreateProjectModalVisible, errorCreatingProject, isFilterVisible } = this.state
+    const { errorCreatingProject, isFilterVisible } = this.state
     return nextProps.user.handle !== user.handle
     || JSON.stringify(nextProps.criteria) !== JSON.stringify(criteria)
     || nextProps.creatingProject !== creatingProject
     || nextProps.projectCreationError !== projectCreationError
     || nextProps.searchTermTag !== searchTermTag
-    || nextState.isCreateProjectModalVisible !== isCreateProjectModalVisible
     || nextState.errorCreatingProject !== errorCreatingProject
     || nextState.isFilterVisible !== isFilterVisible
   }
 
   render() {
     const { logo, userMenu, userRoles, criteria, isPowerUser } = this.props
-    const { isCreateProjectModalVisible, errorCreatingProject, isFilterVisible } = this.state
+    const { errorCreatingProject, isFilterVisible } = this.state
     const isLoggedIn = userRoles && userRoles.length
 
     const noOfFilters = _.keys(criteria).length - 1 // -1 for default sort criteria
 
     return (
       <div className="ProjectsToolBar">
-        <Modal
-          isOpen={ isCreateProjectModalVisible }
-          className="project-creation-dialog"
-          overlayClassName="project-creation-dialog-overlay"
-          onRequestClose={ this.hideCreateProjectDialog }
-          contentLabel=""
-        >
-          <ModalControl
-            className="escape-button"
-            icon={<SVGIconImage filePath="x-mark" />}
-            label="esc"
-            onClick={ this.hideCreateProjectDialog }
-          />
-          { !errorCreatingProject &&
-            <ProjectWizard
-              showModal={ false }
-              processing={ this.props.creatingProject }
-              createProject={ this.createProject }
-              closeModal={ this.hideCreateProjectDialog }
-              userRoles={ userRoles }
-              onProjectUpdate={ (updatedProject, dirty=true) => {
-                this.setState({
-                  isProjectDirty: dirty
-                })
-              }
-              }
-            />
-          }
-          { errorCreatingProject && <CoderBot code={ 500 } message="Unable to create project" />}
-        </Modal>
         <div className="primary-toolbar">
           { logo }
           {
@@ -240,7 +177,7 @@ class ProjectsToolBar extends Component {
           {
             !!isLoggedIn &&
             <div>
-              <a onClick={ this.showCreateProjectDialog } href="javascript:" className="tc-btn tc-btn-sm tc-btn-primary">+ New Project</a>
+              <Link to="/new-project" className="tc-btn tc-btn-sm tc-btn-primary">+ New Project</Link>
             </div>
           }
           { userMenu }
@@ -289,6 +226,6 @@ const mapStateToProps = ({ projectSearchSuggestions, searchTerm, projectSearch, 
   }
 }
 
-const actionsToBind = { projectSuggestions, loadProjects, createProjectAction }
+const actionsToBind = { projectSuggestions, loadProjects }
 
 export default connect(mapStateToProps, actionsToBind)(ProjectsToolBar)

--- a/src/config/projectWizard/index.js
+++ b/src/config/projectWizard/index.js
@@ -116,7 +116,7 @@ const products = {
         details: 'Translate designs to a web (HTML/CSS/JavaScript) or mobile prototype',
         icon: 'product-dev-prototype',
         id: 'visual_prototype',
-        aliases: ['visual-prototype','visual_prototype'],
+        aliases: ['visual-prototype', 'visual_prototype'],
         disabled: true
       },
       'Front-end': {

--- a/src/projects/create/containers/CreateContainer.jsx
+++ b/src/projects/create/containers/CreateContainer.jsx
@@ -143,6 +143,8 @@ class CreateConainer extends React.Component {
   closeWizard() {
     const { userRoles } = this.props
     const isLoggedIn = userRoles && userRoles.length > 0
+    // calls leave handler
+    this.onLeave()
     if (isLoggedIn) {
       this.props.router.push('/projects')
     } else {

--- a/src/projects/create/containers/CreateContainer.jsx
+++ b/src/projects/create/containers/CreateContainer.jsx
@@ -58,6 +58,7 @@ class CreateConainer extends React.Component {
     }
     this.createProject = this.createProject.bind(this)
     this.onLeave = this.onLeave.bind(this)
+    this.closeWizard = this.closeWizard.bind(this)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -139,12 +140,24 @@ class CreateConainer extends React.Component {
     })
   }
 
+  closeWizard() {
+    const { userRoles } = this.props
+    const isLoggedIn = userRoles && userRoles.length > 0
+    if (isLoggedIn) {
+      this.props.router.push("/projects")
+    } else {
+      this.props.router.push("/")
+    }
+  }
+
   render() {
     return (
       <EnhancedCreateView
         {...this.props}
         createProject={ this.createProject }
         processing={ this.state.creatingProject }
+        showModal={true}
+        closeModal={ this.closeWizard }
         onStepChange={ (wizardStep, updatedProject) => {
           // type of the project
           let projectType = _.get(updatedProject, 'type', null)

--- a/src/projects/create/containers/CreateContainer.jsx
+++ b/src/projects/create/containers/CreateContainer.jsx
@@ -144,9 +144,9 @@ class CreateConainer extends React.Component {
     const { userRoles } = this.props
     const isLoggedIn = userRoles && userRoles.length > 0
     if (isLoggedIn) {
-      this.props.router.push("/projects")
+      this.props.router.push('/projects')
     } else {
-      this.props.router.push("/")
+      this.props.router.push('/')
     }
   }
 
@@ -156,7 +156,7 @@ class CreateConainer extends React.Component {
         {...this.props}
         createProject={ this.createProject }
         processing={ this.state.creatingProject }
-        showModal={true}
+        showModal
         closeModal={ this.closeWizard }
         onStepChange={ (wizardStep, updatedProject) => {
           // type of the project
@@ -172,7 +172,9 @@ class CreateConainer extends React.Component {
           // updates the productType variable to use first alias to create SEO friendly URL
           productType = _.get(product, 'aliases[0]', productType)
           if (wizardStep === ProjectWizard.Steps.WZ_STEP_INCOMP_PROJ_CONF) {
-            browserHistory.push(NEW_PROJECT_PATH + '/incomplete')
+            let productUrl = productType ? ('/' + productType) : ''
+            productUrl = !productType && projectType ? ('/' + projectType) : productUrl
+            browserHistory.push(NEW_PROJECT_PATH + productUrl + '/incomplete')
           }
           if (wizardStep === ProjectWizard.Steps.WZ_STEP_SELECT_PROJ_TYPE) {
             browserHistory.push(NEW_PROJECT_PATH + '/' + window.location.search)

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -104,7 +104,7 @@ const renderTopBarWithProjectsToolBar = (props) => <TopBarContainer toolbar={ Pr
 export default (
   <Route path="/" onUpdate={() => window.scrollTo(0, 0)} component={ App } onEnter={ redirectToConnect }>
     <IndexRoute components={{ topbar: renderTopBarWithProjectsToolBar, content: Home }} />
-    <Route path="/new-project(/:product)" components={{ topbar: null, content: CreateContainer }} onEnter={ validateCreateProjectParams } />
+    <Route path="/new-project(/:product)(/:status)" components={{ topbar: null, content: CreateContainer }} onEnter={ validateCreateProjectParams } />
     <Route path="/new-project-callback" components={{ topbar: null, content: CreateContainer }} />
     <Route path="/terms" components={{ topbar: renderTopBarWithProjectsToolBar, content: ConnectTerms }}  />
     <Route path="/login" components={{ topbar: renderTopBarWithProjectsToolBar, content: LoginRedirect }} />


### PR DESCRIPTION
Github issue#1234, Functions of the "Connect Logo", "Back", "Esc" buttons in logged in and logged out states
Github issue#1035, URL does not change when selecting project from "New Project" page
— Removed modal view of create project wizard for logged in user.

Fixed bug around handling incomplete project screen and its after steps after changes for GitHub issues#1235,1104,1035