### PR TITLE
Footer updates fix #1322

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -9,8 +9,7 @@ const Footer = () => {
   const currentYear = moment().format('YYYY')
   const otherNavigationItems = [
     {img: '', text: 'About', link: 'https://www.topcoder.com/about-topcoder/', target: '_blank'},
-    {img: '', text: 'Contact', link: 'https://www.topcoder.com/about-topcoder/contact/', target: '_blank'},
-    {img: '', text: 'Help', link: 'https://help.topcoder.com/hc/en-us/articles/225540188-Topcoder-Connect-FAQs', target: '_blank'},
+    {img: '', text: 'Contact us', link: 'https://www.topcoder.com/about-topcoder/contact/', target: '_blank'},
     {img: '', text: 'Privacy', link: 'https://www.topcoder.com/community/how-it-works/privacy-policy/', target: '_blank'},
     {img: '', text: 'Terms', link: 'https://connect.topcoder.com/terms'}
   ]

--- a/src/components/FooterV2/FooterV2.jsx
+++ b/src/components/FooterV2/FooterV2.jsx
@@ -6,8 +6,7 @@ const FooterV2 = () => (
   <div className="footer-v2">
     <ul className="footer-links">
       <li><a href="https://www.topcoder.com/about-topcoder/" target="_blank">About</a></li>
-      <li><a href="https://www.topcoder.com/about-topcoder/contact/" target="_blank">Contact</a></li>
-      <li><a href="https://help.topcoder.com/hc/en-us/articles/225540188-Topcoder-Connect-FAQs" target="_blank">Help</a></li>
+      <li><a href="https://www.topcoder.com/about-topcoder/contact/" target="_blank">Contact us</a></li>
       <li><a href="https://www.topcoder.com/community/how-it-works/privacy-policy/" target="_blank">Privacy</a></li>
       <li><a href="https://connect.topcoder.com/terms">Terms</a></li>
     </ul>


### PR DESCRIPTION
Remove "Help" from connect footer.
Rename "Contact" to "Contact us"