### PR TITLE
issue #1373 - Replace project paging with lazy loading

### DIFF
--- a/src/api/projects.js
+++ b/src/api/projects.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 import { axiosInstance as axios } from './requestInterceptor'
-import { TC_API_URL } from '../config/constants'
+import { TC_API_URL, PROJECTS_LIST_PER_PAGE } from '../config/constants'
 
 export function getProjects(criteria, pageNum) {
   // add default params
   const includeFields = ['id', 'name', 'description', 'members', 'status', 'type', 'actualPrice', 'estimatedPrice', 'createdAt', 'updatedAt', 'details']
   const params = {
-    limit: 20,
-    offset: (pageNum - 1) * 20,
+    limit: PROJECTS_LIST_PER_PAGE,
+    offset: (pageNum - 1) * PROJECTS_LIST_PER_PAGE,
     fields: includeFields.join(',')
   }
   // filters

--- a/src/components/Grid/GridView.jsx
+++ b/src/components/Grid/GridView.jsx
@@ -2,11 +2,15 @@ import React, { PropTypes } from 'react'
 import ListHeader from './ListHeader'
 import ListItem from './ListItem'
 import PaginationBar from './PaginationBar'
+import InfiniteScroll from 'react-infinite-scroller'
+import LoadingIndicator from '../../components/LoadingIndicator/LoadingIndicator'
+import { PROJECTS_LIST_PER_PAGE } from '../../config/constants'
 import './GridView.scss'
 
 
 const GridView = props => {
-  const { columns, sortHandler, currentSortField, ListComponent, resultSet, onPageChange, totalCount, pageSize, currentPageNum } = props
+  const { columns, sortHandler, currentSortField, ListComponent, resultSet, onPageChange, projectsStatus,
+    totalCount, pageSize, currentPageNum, infiniteScroll, infiniteAutoload, isLoading, setInfiniteAutoload } = props
   const paginationProps = { totalCount, pageSize, currentPageNum, onPageChange }
   const headerProps = { columns, sortHandler, currentSortField }
 
@@ -14,15 +18,17 @@ const GridView = props => {
     return <ListComponent columns={columns} item={item} key={index}/>
   }
 
-  // TODO replace this with proper style
-  const emptyList = <div style={{textAlign: 'center'}}><br/><br/><h3> No results </h3><br/><br/></div>
+  const handleLoadMore = () => {
+    onPageChange(currentPageNum + 1)
+    setInfiniteAutoload(true)
+  }
 
-  return (
-    <section className="content gridview-content">
+  const renderGridWithPagination = () => (
+    isLoading ? (
+      <LoadingIndicator />
+    ) : (
       <div className="container">
-        {
-          resultSet.length
-          ?
+        {resultSet.length ? (
           <div className="flex-area">
             <div className="flex-data">
               <ListHeader {...headerProps} />
@@ -30,11 +36,55 @@ const GridView = props => {
             </div>
             <PaginationBar {...paginationProps} />
           </div>
-          :
-          <div className="flex-area">{emptyList}</div>
-        }
+        ) : (
+          <div className="flex-area">
+            {/* TODO replace this with proper style */}
+            <div style={{textAlign: 'center'}}><br/><br/><h3> No results </h3><br/><br/></div>
+          </div>
+        )}
       </div>
-      {/* .container */}
+    )
+  )
+
+  const renderGridWithInfiniteScroll = () => {
+    const hasMore = currentPageNum * PROJECTS_LIST_PER_PAGE < totalCount
+
+    return (
+      isLoading && currentPageNum === 1 ? (
+        <LoadingIndicator />
+      ) : (
+        <div>
+          <div className="container">
+            <div className="flex-area">
+              <div className="flex-data">
+                <ListHeader {...headerProps} />
+                <InfiniteScroll
+                  initialLoad={false}
+                  pageStart={currentPageNum}
+                  loadMore={infiniteAutoload ? onPageChange : () => {}}
+                  hasMore={hasMore}
+                  threshold={500}
+                >
+                  {resultSet.map(renderItem)}
+                </InfiniteScroll>
+              </div>
+            </div>
+          </div>
+          { isLoading && <LoadingIndicator /> }
+          { !isLoading && !infiniteAutoload && hasMore &&
+            <div className="gridview-load-more">
+              <button type="button" className="tc-btn tc-btn-primary" onClick={handleLoadMore} key="loadMore">Load more projects</button>
+            </div>
+          }
+          { !isLoading && !hasMore && <div key="end" className="gridview-no-more">No more {projectsStatus} projects</div>}
+        </div>
+      )
+    )
+  }
+
+  return (
+    <section className="content gridview-content">
+      {infiniteScroll ? renderGridWithInfiniteScroll() : renderGridWithPagination()}
     </section>
   )
 }
@@ -48,10 +98,14 @@ GridView.propTypes = {
   resultSet: PropTypes.arrayOf(PropTypes.object).isRequired,
   totalCount: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
-  currentPageNum: PropTypes.number.isRequired
+  currentPageNum: PropTypes.number.isRequired,
+  infiniteAutoload: PropTypes.bool,
+  infiniteScroll: PropTypes.bool,
+  setInfiniteAutoload: PropTypes.func
 }
 
 GridView.defaultProps = {
+  infiniteScroll: false,
   ListComponent: ListItem
 }
 export default GridView

--- a/src/components/Grid/GridView.scss
+++ b/src/components/Grid/GridView.scss
@@ -257,6 +257,18 @@
         text-overflow: ellipsis;
     }
 }
+
+.gridview-load-more {
+  text-align: center;
+}
+
+.gridview-no-more {
+  @include roboto
+  color: $tc-gray-40;
+  font-size: 13px;
+  padding: 10px 0;
+  text-align: center;
+}
 /* .user-block  - remove as it is extended at UserWithName.scss */
 
 // .user-block {
@@ -298,7 +310,7 @@
 //         line-height: $base-unit * 6;
 //         display: inline-block;
 //     }
-    
+
 //     .item-mask-layer {
 //         background: rgba(255,255,255,0.7);
 //         width: 100%;

--- a/src/components/TopBar/ProjectsToolBar.js
+++ b/src/components/TopBar/ProjectsToolBar.js
@@ -10,7 +10,7 @@ import { SearchBar, MenuBar, SwitchButton } from 'appirio-tech-react-components'
 import Filters from './Filters'
 import NewProjectNavLink from './NewProjectNavLink'
 
-import { projectSuggestions, loadProjects } from '../../projects/actions/loadProjects'
+import { projectSuggestions, loadProjects, setInfiniteAutoload } from '../../projects/actions/loadProjects'
 
 
 class ProjectsToolBar extends Component {
@@ -88,7 +88,7 @@ class ProjectsToolBar extends Component {
       // force sort criteria to best match
       criteria.sort = 'best match'
     }
-    this.routeWithParams(criteria, 1)
+    this.routeWithParams(criteria)
   }
 
   toggleFilter() {
@@ -103,14 +103,16 @@ class ProjectsToolBar extends Component {
     })
   }
 
-  routeWithParams(criteria, page) {
+  routeWithParams(criteria) {
+    // because criteria is changed disable infinite autoload
+    this.props.setInfiniteAutoload(false)
     // remove any null values
     criteria = _.pickBy(criteria, _.identity)
     this.props.history.push({
       pathname: '/projects',
-      query: '?' + querystring.stringify(_.assign({}, criteria, { page }))
+      search: '?' + querystring.stringify(_.assign({}, criteria))
     })
-    this.props.loadProjects(criteria, page)
+    this.props.loadProjects(criteria)
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -225,7 +227,8 @@ ProjectsToolBar.propTypes = {
   /**
    * Function which render the logo section in the top bar
    */
-  renderLogoSection     : PropTypes.func.isRequired
+  renderLogoSection     : PropTypes.func.isRequired,
+  setInfiniteAutoload   : PropTypes.func.isRequired
 }
 
 ProjectsToolBar.defaultProps = {
@@ -247,6 +250,6 @@ const mapStateToProps = ({ projectSearchSuggestions, searchTerm, projectSearch, 
   }
 }
 
-const actionsToBind = { projectSuggestions, loadProjects }
+const actionsToBind = { projectSuggestions, loadProjects, setInfiniteAutoload }
 
 export default withRouter(connect(mapStateToProps, actionsToBind)(ProjectsToolBar))

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -22,7 +22,8 @@ export const GET_PROJECTS               = 'GET_PROJECTS'
 export const GET_PROJECTS_PENDING       = 'GET_PROJECTS_PENDING'
 export const GET_PROJECTS_SUCCESS       = 'GET_PROJECTS_SUCCESS'
 export const GET_PROJECTS_FAILURE       = 'GET_PROJECTS_FAILURE'
-export const GET_PROJECTS_SEARCH_CRITERIA = 'GET_PROJECTS_SEARCH_CRITERIA'
+export const SET_PROJECTS_SEARCH_CRITERIA = 'SET_PROJECTS_SEARCH_CRITERIA'
+export const SET_PROJECTS_INFINITE_AUTOLOAD = 'SET_PROJECTS_INFINITE_AUTOLOAD'
 
 
 // Delete project
@@ -268,3 +269,7 @@ export const GA_CLIENT_ID = '_gacid'
 
 // ToolTip
 export const TOOLTIP_DEFAULT_DELAY = 300 // in ms
+
+
+// Projects list
+export const PROJECTS_LIST_PER_PAGE = 20

--- a/src/projects/actions/loadProjects.js
+++ b/src/projects/actions/loadProjects.js
@@ -1,9 +1,10 @@
 import _ from 'lodash'
 import {
   PROJECT_SEARCH, GET_PROJECTS, PROJECT_STATUS, PROJECT_STATUS_CANCELLED,
-  SET_SEARCH_TERM, GET_PROJECTS_SEARCH_CRITERIA,
+  SET_SEARCH_TERM, SET_PROJECTS_SEARCH_CRITERIA,
   CLEAR_PROJECT_SUGGESTIONS_SEARCH, PROJECT_SUGGESTIONS_SEARCH_SUCCESS,
-  ROLE_CONNECT_COPILOT, ROLE_CONNECT_MANAGER, ROLE_ADMINISTRATOR
+  ROLE_CONNECT_COPILOT, ROLE_CONNECT_MANAGER, ROLE_ADMINISTRATOR,
+  SET_PROJECTS_INFINITE_AUTOLOAD
 } from '../../config/constants'
 import { getProjects } from '../../api/projects'
 import { loadMembers } from '../../actions/members'
@@ -13,13 +14,15 @@ import { loadMembers } from '../../actions/members'
 const getProjectsWithMembers = (dispatch, getState, criteria, pageNum) => {
   return new Promise((resolve, reject) => {
     dispatch({
-      type: GET_PROJECTS_SEARCH_CRITERIA,
+      type: SET_PROJECTS_SEARCH_CRITERIA,
       criteria,
       pageNum
     })
+
     // for non power users, we hard coding the project status to not show Cancelled projects
     // we don't want the URL to clutter with this, hence criteria has to modified just before passing to the API
     // NOTE: we need to remove this if we provide status filter for such users
+    const requestCriteria = {...criteria} // make a copy of criteria to NOT to change it in the redux store
     let isPowerUser = false
     const loadUser = getState().loadUser
     // power user roles
@@ -33,15 +36,16 @@ const getProjectsWithMembers = (dispatch, getState, criteria, pageNum) => {
         // statuses to be excluded for non power users
         const excluded = [PROJECT_STATUS_CANCELLED]
         // updates the criteria with status filter
-        _.set(criteria, 'status', `in(${_.difference(statuses, excluded)})`)
+        _.set(requestCriteria, 'status', `in(${_.difference(statuses, excluded)})`)
       }
     }
+
     return dispatch({
       type: GET_PROJECTS,
-      payload: getProjects(criteria, pageNum),
+      payload: getProjects(requestCriteria, pageNum),
       meta: {
-        // for non power users (i.e. customers) keep previous to enable the loading without paginator
-        keepPrevious : !isPowerUser
+        // keep previous to enable the loading without paginator (infinite scroll)
+        keepPrevious : pageNum !== 1
       }
     })
     .then(({ value, action }) => {
@@ -67,7 +71,11 @@ export function loadProjects(criteria, pageNum=1) {
   return (dispatch, getState) => {
     return dispatch({
       type: PROJECT_SEARCH,
-      payload: getProjectsWithMembers(dispatch, getState, criteria, pageNum)
+      payload: getProjectsWithMembers(dispatch, getState, criteria, pageNum),
+      meta: {
+        // keep previous to enable the loading without paginator (infinite scroll)
+        keepPrevious : pageNum !== 1
+      }
     })
   }
 }
@@ -92,6 +100,12 @@ export function projectSuggestions(searchTerm) {
     })
 
   })
+}
+
+export function setInfiniteAutoload(infiniteAutload) {
+  return (dispatch) => {
+    dispatch({ type: SET_PROJECTS_INFINITE_AUTOLOAD, payload: infiniteAutload })
+  }
 }
 
 /**

--- a/src/projects/list/components/Projects/Projects.jsx
+++ b/src/projects/list/components/Projects/Projects.jsx
@@ -9,7 +9,7 @@ import ProjectsCardView from './ProjectsCardView'
 import { loadProjects, setInfiniteAutoload } from '../../../actions/loadProjects'
 import _ from 'lodash'
 import querystring from 'query-string'
-import { ROLE_CONNECT_MANAGER, ROLE_CONNECT_COPILOT, ROLE_ADMINISTRATOR } from '../../../../config/constants'
+import { ROLE_CONNECT_MANAGER, ROLE_CONNECT_COPILOT, ROLE_ADMINISTRATOR, PROJECT_STATUS } from '../../../../config/constants'
 
 /*
   Definiing default project criteria. This is used to later to determine if
@@ -129,6 +129,11 @@ class Projects extends Component {
     const showWalkThrough = !isLoading && totalCount === 0 &&
       _.isEqual(criteria, defaultCriteria) &&
       !isPowerUser
+
+    const getStatusCriteriaText = (criteria) => {
+      return (_.find(PROJECT_STATUS, { value: criteria.status }) || { name: ''}).name
+    }
+
     const projectsView = isPowerUser
       ? (
         <EnhancedGrid
@@ -136,7 +141,7 @@ class Projects extends Component {
           onPageChange={this.onPageChange}
           sortHandler={this.sortHandler}
           applyFilters={this.applyFilters}
-          projectsStatus={criteria.status || ''}
+          projectsStatus={getStatusCriteriaText(criteria)}
         />
       )
       : (
@@ -146,7 +151,7 @@ class Projects extends Component {
           // sortHandler={this.sortHandler}
           applyFilters={this.applyFilters}
           onPageChange={this.onPageChange}
-          projectsStatus={criteria.status || ''}
+          projectsStatus={getStatusCriteriaText(criteria)}
         />
       )
     return (

--- a/src/projects/list/components/Projects/ProjectsCardView.jsx
+++ b/src/projects/list/components/Projects/ProjectsCardView.jsx
@@ -4,7 +4,7 @@ import InfiniteScroll from 'react-infinite-scroller'
 import ProjectCard from './ProjectCard'
 import NewProjectCard from './NewProjectCard'
 import LoadingIndicator from '../../../../components/LoadingIndicator/LoadingIndicator'
-
+import { PROJECTS_LIST_PER_PAGE } from '../../../../config/constants'
 import { setDuration } from '../../../../helpers/projectHelper'
 
 require('./ProjectsGridView.scss')
@@ -13,7 +13,7 @@ require('./ProjectsGridView.scss')
 const ProjectsCardView = props => {
   //const { projects, members, totalCount, criteria, pageNum, applyFilters, sortHandler, onPageChange, error, isLoading, onNewProjectIntent } = props
   // TODO: use applyFilters and onNewProjectIntent. Temporary delete to avoid lint errors.
-  const { projects, members, currentUser, onPageChange, pageNum, totalCount, inifinite } = props
+  const { projects, members, currentUser, onPageChange, pageNum, totalCount, infiniteAutoload, setInfiniteAutoload, isLoading, projectsStatus } = props
   // const currentSortField = _.get(criteria, 'sort', '')
 
   // annotate projects with member data
@@ -28,9 +28,9 @@ const ProjectsCardView = props => {
     })
   })
 
-  const renderProject = (project, index) => {
+  const renderProject = (project) => {
     const duration = setDuration({}, project.status)
-    return (<div key={index} className="project-card">
+    return (<div key={project.id} className="project-card">
       <ProjectCard
         project={project}
         currentUser={currentUser}
@@ -40,30 +40,25 @@ const ProjectsCardView = props => {
   }
   const handleLoadMore = () => {
     onPageChange(pageNum + 1)
+    setInfiniteAutoload(true)
   }
-  const hasMore = ((pageNum - 1) * 20 + 20 < totalCount)
+  const hasMore = pageNum * PROJECTS_LIST_PER_PAGE < totalCount
+
   return (
     <div className="projects card-view">
-      { !!inifinite && 
-        <InfiniteScroll
-          initialLoad={false}
-          pageStart={pageNum}
-          loadMore={onPageChange}
-          hasMore={ hasMore }
-          loader={<LoadingIndicator />}
-        >
-          { projects.map(renderProject)}
-          <div className="project-card"><NewProjectCard /></div>
-        </InfiniteScroll>
-      }
-      { !inifinite &&
-        <div>
-          { projects.map(renderProject)}
-          <div className="project-card"><NewProjectCard /></div>
-        </div>
-      }
-      { !inifinite && hasMore && <button type="button" className="tc-btn tc-btn-primary" onClick={handleLoadMore}>Load more</button> }
-      { !hasMore && <span>End of results</span>}
+      <InfiniteScroll
+        initialLoad={false}
+        pageStart={pageNum}
+        loadMore={infiniteAutoload ? onPageChange : () => {}}
+        hasMore={hasMore}
+        threshold={500}
+      >
+        { projects.map(renderProject)}
+        <div className="project-card"><NewProjectCard /></div>
+      </InfiniteScroll>
+      { isLoading && <LoadingIndicator /> }
+      { !isLoading && !infiniteAutoload && hasMore && <button type="button" className="tc-btn tc-btn-primary" onClick={handleLoadMore} key="loadMore">Load more projects</button>}
+      { !isLoading && !hasMore && <span key="end">No more {projectsStatus} projects</span>}
     </div>
   )
 }
@@ -81,13 +76,16 @@ ProjectsCardView.propTypes = {
   // onPageChange: PropTypes.func.isRequired,
   // sortHandler: PropTypes.func.isRequired,
   // applyFilters: PropTypes.func.isRequired,
-  pageNum: PropTypes.number.isRequired
+  pageNum: PropTypes.number.isRequired,
   // criteria: PropTypes.object.isRequired
+  infiniteAutoload: PropTypes.bool,
+  setInfiniteAutoload: PropTypes.func,
+  isLoading: PropTypes.bool
 }
 
 
 ProjectsCardView.defaultProps = {
-  inifinite : false
+  infiniteAutoload : false
 }
 
 export default ProjectsCardView

--- a/src/projects/list/components/Projects/ProjectsGridView.jsx
+++ b/src/projects/list/components/Projects/ProjectsGridView.jsx
@@ -8,7 +8,7 @@ import GridView from '../../../../components/Grid/GridView'
 
 import UserWithName from '../../../../components/User/UserWithName'
 import { findCategory } from '../../../../config/projectWizard'
-import { PROJECT_STATUS } from '../../../../config/constants'
+import { PROJECT_STATUS, PROJECTS_LIST_PER_PAGE } from '../../../../config/constants'
 
 require('./ProjectsGridView.scss')
 
@@ -29,7 +29,8 @@ const projectTypeClassMap = {
 const ProjectsGridView = props => {
   //const { projects, members, totalCount, criteria, pageNum, applyFilters, sortHandler, onPageChange, error, isLoading, onNewProjectIntent } = props
   // TODO: use applyFilters and onNewProjectIntent. Temporary delete to avoid lint errors.
-  const { projects, members, totalCount, criteria, pageNum, sortHandler, onPageChange, error, isLoading} = props
+  const { projects, members, totalCount, criteria, pageNum, sortHandler, onPageChange,
+    error, isLoading, infiniteAutoload, setInfiniteAutoload, projectsStatus } = props
   const currentSortField = _.get(criteria, 'sort', '')
   // This 'little' array is the heart of the list component.
   // it defines what columns should be displayed and more importantly
@@ -178,6 +179,7 @@ const ProjectsGridView = props => {
       members[m.userId.toString()])
     })
   })
+
   const gridProps = {
     error,
     isLoading,
@@ -188,7 +190,11 @@ const ProjectsGridView = props => {
     resultSet: projects,
     totalCount,
     currentPageNum: pageNum,
-    pageSize: 20
+    pageSize: PROJECTS_LIST_PER_PAGE,
+    infiniteAutoload,
+    infiniteScroll: true,
+    setInfiniteAutoload,
+    projectsStatus
   }
 
   return (

--- a/src/projects/reducers/projectSearch.js
+++ b/src/projects/reducers/projectSearch.js
@@ -1,7 +1,8 @@
 import {
   PROJECT_SEARCH_PENDING, PROJECT_SEARCH_SUCCESS, PROJECT_SEARCH_FAILURE,
   GET_PROJECTS_PENDING, GET_PROJECTS_SUCCESS, GET_PROJECTS_FAILURE,
-  LOAD_MORE_PROJECTS, CLEAR_PROJECT_SEARCH, GET_PROJECTS_SEARCH_CRITERIA
+  LOAD_MORE_PROJECTS, CLEAR_PROJECT_SEARCH, SET_PROJECTS_SEARCH_CRITERIA,
+  SET_PROJECTS_INFINITE_AUTOLOAD
 } from '../../config/constants'
 import update from 'react-addons-update'
 
@@ -25,9 +26,9 @@ export default function(state = initialState, action) {
     return Object.assign({}, state, {
       isLoading: true,
       error: false,
-      totalCount: 0
+      totalCount: action.meta && action.meta.keepPrevious ? state.totalCount : 0
     })
-  case GET_PROJECTS_SEARCH_CRITERIA:
+  case SET_PROJECTS_SEARCH_CRITERIA:
     return Object.assign({}, state, {
       criteria: action.criteria,
       pageNum: action.pageNum
@@ -63,6 +64,11 @@ export default function(state = initialState, action) {
   case LOAD_MORE_PROJECTS:
     return Object.assign({}, state, {
       loadingMore: true
+    })
+
+  case SET_PROJECTS_INFINITE_AUTOLOAD:
+    return Object.assign({}, state, {
+      infiniteAutoload: action.payload
     })
 
   default:


### PR DESCRIPTION
# Issue #1373 - Replace project paging with lazy loading

## Implementation notes:
- Infinite scrolling implemented for both `grid` and `card` view
- `page` param was removed from the URL
- ~~NOTE As I don't have a user with proper credentials to test `grid` view I tested solution by temporary patching some `isPowerUser` flags in the code. If you could share credentials for a powerful user I can test in real conditions.~~ (Tested with proper credentials and fixed)


## Fixes
- When go to the next page `&status=in%28draft%2Cin_review%2Creviewed%2Cactive%2Ccompleted%2Cpaused%29` was added to the URL. Though it shouldn't. This part of requests is just inner mechanism of filtering canceled projects for regular users.


## Possible issues

- On the projects list page, in `cards view` mode, there is warning in browser console:
  ```
  warning.js:35 Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>. See ProjectCard > Link > a > ... > ProjectCardBody > Link > a.
  ```

- Looks like some projects in the list cause the next three warning in `grid view`:

  ```
  Warning: Failed prop type: The prop `handle` is marked as required in `UserWithName`, but its value is `undefined`.

  warning.js:35 Warning: Failed prop type: The prop `firstName` is marked as required in `UserWithName`, but its value is `undefined`.

  warning.js:35 Warning: Failed prop type: The prop `lastName` is marked as required in `UserWithName`, but its value is `undefined`.
  ```

  I blame project with id `271`, because he has `Unknown` value is the `Customer` column.
