### PR TITLE
Issue #1465 - hide email settings column and replace it with a link

### DIFF
--- a/src/routes/settings/routes/notifications/components/NotificationSettingsForm.jsx
+++ b/src/routes/settings/routes/notifications/components/NotificationSettingsForm.jsx
@@ -110,7 +110,8 @@ class NotificationSettingsForm extends React.Component {
           <tr>
             <th>Notifications</th>
             <th><span className="th-with-icon"><img src={iconWeb} /><span>Web</span></span></th>
-            <th><span className="th-with-icon"><img src={iconMail} /><span>Email</span></span></th>
+            {/* as email notification currently not supported, hide them for now */}
+            {/*<th><span className="th-with-icon"><img src={iconMail} /><span>Email</span></span></th>*/}
           </tr>
         </thead>
         <tbody>
@@ -120,7 +121,8 @@ class NotificationSettingsForm extends React.Component {
               <tr key={topic}>
                 <th>{title}</th>
                 <td><SwitchButton onChange={() => this.handleChange(topic, 'web')} defaultChecked={settings[topic] && settings[topic].web === 'yes'} /></td>
-                <td><SwitchButton onChange={() => this.handleChange(topic, 'email')} defaultChecked={settings[topic] && settings[topic].email === 'yes'} /></td>
+                {/* as email notification currently not supported, hide them for now */}
+                {/*<td><SwitchButton onChange={() => this.handleChange(topic, 'email')} defaultChecked={settings[topic] && settings[topic].email === 'yes'} /></td>*/}
               </tr>
             )
           })}
@@ -144,6 +146,10 @@ class NotificationSettingsForm extends React.Component {
           }
         </tbody>
       </table>
+
+      <div className="email-settings">
+        <a href="https://www.topcoder.com/settings/email/">Manage email settings</a>
+      </div>
 
       <div className="controls">
         <button type="submit" className="tc-btn tc-btn-primary" disabled={this.props.values.pending}>Save settings</button>

--- a/src/routes/settings/routes/notifications/components/NotificationSettingsForm.scss
+++ b/src/routes/settings/routes/notifications/components/NotificationSettingsForm.scss
@@ -55,6 +55,10 @@
       }
     }
 
+    tbody > tr:last-child {
+      border-bottom: 1px solid $tc-gray-50;
+    }
+
     .fixed-value {
       @include roboto-medium;
       background-color: $tc-gray-40;
@@ -108,5 +112,24 @@
   > .controls {
     margin-top: 10px;
     text-align: center;
+  }
+
+  > .email-settings {
+    @include roboto;
+    margin: 20px 0;
+
+    a {
+      text-decoration: underline;
+    }
+    // Link colors
+    a:link,
+    a:visited {
+      color: $tc-dark-blue;
+    }
+
+    a:hover,
+    a:active {
+      color: $tc-dark-blue-70;
+    }
   }
 }


### PR DESCRIPTION
Issue #1465 - hide email settings column and replace it with a link to email settings

Here is how it looks

![](https://api.monosnap.com/rpc/file/download?id=Gve4ESoXuSvhHtZotvrAaduahhpzlj)