### PR TITLE
Issue #1507 - Clicking on project post notification doesn't enable the Dashboard section

### DIFF
--- a/src/components/ActionCard/Comment.jsx
+++ b/src/components/ActionCard/Comment.jsx
@@ -3,6 +3,7 @@ import cn from 'classnames'
 import Panel from '../Panel/Panel'
 import { Avatar } from 'appirio-tech-react-components'
 import RichTextArea from '../RichTextArea/RichTextArea'
+import { Link } from 'react-router-dom'
 import CommentEditToggle from './CommentEditToggle'
 
 class Comment extends React.Component {

--- a/src/projects/detail/ProjectDetail.jsx
+++ b/src/projects/detail/ProjectDetail.jsx
@@ -47,12 +47,17 @@ class ProjectDetail extends Component {
     this.props.loadProjectDashboard(projectId)
   }
 
-  componentWillReceiveProps({isProcessing, isLoading, error, project}) {
+  componentWillReceiveProps({isProcessing, isLoading, error, project, match}) {
     // handle just deleted projects
     if (! (error || isLoading || isProcessing) && _.isEmpty(project))
       this.props.history.push('/projects/')
     if (project && project.name) {
       document.title = `${project.name} - Topcoder`
+    }
+
+    // load project if URL changed
+    if (this.props.match.params.projectId !== match.params.projectId) {
+      this.props.loadProjectDashboard(match.params.projectId)
     }
   }
 


### PR DESCRIPTION
Issue #1507 - Clicking on project post notification doesn't enable the Dashboard section
Project wasn’t switched at all when we click links to another project from the project page.