### PR TITLE
issue-1616

### DIFF
--- a/src/components/TeamManagement/TeamManagement.scss
+++ b/src/components/TeamManagement/TeamManagement.scss
@@ -242,7 +242,7 @@ $tc-body-extra-small: 12px;
         margin-bottom: $base-unit*2;
 
         button {
-          margin-left: $base-unit*2;
+          padding: 0 $base-unit*4 $base-unit*4;
         }
 
         .input-icon-group {


### PR DESCRIPTION
In TeamManagement.scss, the style ‘.modal-inline-form button’ had it's margin-left unnecessarily set to $base-unit*2 (10px). The inherited value of 5px was all that was needed…  This along with the button’s inherited left and right padding of 25px created an extra 15px of width overall, causing the container to appear wider than intended. Simply removing this margin-left style doesn’t suffice, since the button’s left and right padding needed to be decreased to 20px each so to correctly reduce the container width by 10px total, as well as to ensure the inner text ‘Add’ is centered. The add team members container now behaves as intended with the correct width.