### PR TITLE
#1603 Search box performance issue

### DIFF
--- a/src/components/TopBar/ProjectsToolBar.js
+++ b/src/components/TopBar/ProjectsToolBar.js
@@ -73,7 +73,6 @@ class ProjectsToolBar extends Component {
 
   /*eslint-disable no-unused-vars */
   handleTermChange(oldTerm, searchTerm, reqNo, callback) {
-    this.props.projectSuggestions(searchTerm)
     callback(reqNo, this.props.projects)
   }
   /*eslint-enable */


### PR DESCRIPTION
onTermChange is required by the SearchBar component from appirio-tech-react-components, and it will be called in SearchBar's onChange function. So handleTermChange is needed here unless we modify SearchBar component. 
callback is necessary to remove the loading spinning logo (which is called by the Search to change its state and hide the loading logo). 
The simplest way the avoid unnecessary action call is to remove the line of calling  this.props.projectSuggestions and keep the callback function to keep the Search Bar work. 
#1603 