### PR TITLE
fix #1774: Search bar showing 2 cross buttons on edge browser

### DIFF
--- a/src/components/TopBar/ProjectsToolBar.scss
+++ b/src/components/TopBar/ProjectsToolBar.scss
@@ -75,6 +75,12 @@
       height: 30px;
       margin-top: 15px;
       display: flex;
+
+      input::-ms-clear{
+        width: 0;
+        height: 0;
+        display: none;
+      }
     }
 
     .search-filter {


### PR DESCRIPTION
fix #1774