### PR TITLE
fix #1804: select a status change without closing the previous modal

### DIFF
--- a/src/components/ProjectStatus/ProjectStatus.scss
+++ b/src/components/ProjectStatus/ProjectStatus.scss
@@ -35,6 +35,16 @@
   }
   
   .EditableProjectStatus {
+    &.modal-active {
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    }
+
     .status-label {
       vertical-align: top;
     }

--- a/src/components/ProjectStatus/editableProjectStatus.js
+++ b/src/components/ProjectStatus/editableProjectStatus.js
@@ -128,7 +128,7 @@ const editableProjectStatus = (CompositeComponent) => class extends Component {
     const ProjectStatusDropdown = canEdit ? enhanceDropdown(hocStatusDropdown(CompositeComponent)) : hocStatusDropdown(CompositeComponent)
     return (
       <div className={cn('EditableProjectStatus', {'modal-active': showStatusChangeDialog})}>
-        <div className="modal-overlay" />
+        <div className="modal-overlay" onClick={ this.hideStatusChangeDialog }/>
         <ProjectStatusDropdown {...this.props } onItemSelect={ this.showStatusChangeDialog } />
         { showStatusChangeDialog &&
           <ProjectStatusChangeConfirmation


### PR DESCRIPTION
fix #1804