### PR TITLE
Fixed code to make maintenance and error pages visible

### DIFF
--- a/src/components/Maintenance/Maintenance.jsx
+++ b/src/components/Maintenance/Maintenance.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import './Maintenance.scss'
 
 const Maintenance = () => {

--- a/src/routes/settings/routes.jsx
+++ b/src/routes/settings/routes.jsx
@@ -2,7 +2,7 @@
  * Settings routes
  */
 import React from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Route } from 'react-router-dom'
 import { renderApp } from '../../components/App/App'
 import TopBarContainer from '../../components/TopBar/TopBarContainer'
 import NotificationsToolBar from '../notifications/components/NotificationsToolBar'
@@ -12,9 +12,7 @@ import NotificationSettingsContainer from './routes/notifications/containers/Not
 // import ProfileSettingsContainer from './routes/profile/containers/ProfileSettingsContainer'
 
 export default (
-  <Switch>
-    {/*<Route path="/settings/profile" render={renderApp(<TopBarContainer toolbar={SettingsToolBar} />, <ProfileSettingsContainer />)} />*/}
-    {/*<Route path="/settings/system" render={renderApp(<TopBarContainer toolbar={SettingsToolBar} />, <SystemSettingsContainer />)} />*/}
-    <Route path="/settings/notifications" render={renderApp(<TopBarContainer toolbar={NotificationsToolBar} />, <NotificationSettingsContainer />)} />
-  </Switch>
+  {/*<Route path="/settings/profile" render={renderApp(<TopBarContainer toolbar={SettingsToolBar} />, <ProfileSettingsContainer />)} />*/},
+  {/*<Route path="/settings/system" render={renderApp(<TopBarContainer toolbar={SettingsToolBar} />, <SystemSettingsContainer />)} />*/},
+  <Route path="/settings/notifications" render={renderApp(<TopBarContainer toolbar={NotificationsToolBar} />, <NotificationSettingsContainer />)} />
 )


### PR DESCRIPTION
Right now maintenance page breaks for me due to missing react import in Maintenance.jsx and /error and /404 error pages are not visible due to screwed up routing in src/routing/settings page. My this pull request fixes both issues to make these pages working. Please give feedback.