### PR TITLE
Handling non 404 more appropriately

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -19,7 +19,7 @@ class Layout extends Component {
 }
 
 const mapStateToProps = ({ loadUser, projectState, projectSearch }) => {
-  const projectDetailApiCheck = !projectState.isLoading && !!projectState.error
+  const projectDetailApiCheck = !projectState.isLoading && !!projectState.error && projectState.error.code === 404
   const projectListingApiCheck = !projectSearch.isLoading && !!projectSearch.error
   return {
     user : loadUser.user,

--- a/src/projects/reducers/project.js
+++ b/src/projects/reducers/project.js
@@ -41,9 +41,10 @@ const initialState = {
 
 const parseErrorObj = (action) => {
   const data = _.get(action.payload, 'response.data.result')
+  const httpStatus = _.get(action.payload, 'response.status')
   return {
     type: action.type,
-    code: _.get(data, 'status', 500),
+    code: _.get(data, 'status', httpStatus || 500),
     msg: _.get(data, 'content.message', ''),
     details: JSON.parse(_.get(data, 'details', null))
   }


### PR DESCRIPTION
Now it should not show maintenance page for 403 or any custom status returned by the API, it should be shown only if the API endpoint does not exist.