### PR TITLE
Reposition load more button under time stamp #2128

### DIFF
--- a/src/components/Feed/FeedComments.jsx
+++ b/src/components/Feed/FeedComments.jsx
@@ -64,15 +64,13 @@ class FeedComments extends React.Component {
     const desktopBlocks = []
     const mobileBlocks = []
 
-    if (hasMoreComments) {
-      desktopBlocks.push(
-        <div styleName="load-more" key="load-more">
-          <a href="javascript:" onClick={ handleLoadMoreClick } styleName="load-btn">
-            {isLoadingComments ? 'Loading...' : 'load earlier posts'}
-          </a>
-        </div>
-      )
-    }
+    const loadMoreTemplate = (
+      <div styleName="load-more" key="load-more">
+        <a href="javascript:" onClick={ handleLoadMoreClick } styleName="load-btn">
+          {isLoadingComments ? 'Loading...' : 'load earlier posts'}
+        </a>
+      </div>
+    )
 
     let bundleCreatedAt = false
     let isBundleEdited = false
@@ -89,7 +87,7 @@ class FeedComments extends React.Component {
 
       const timeDiffComment = bundleCreatedAt && createdAt.diff(bundleCreatedAt)
       const shouldBundle = isSameDay && isSameAuthor && !isFirstUnread && timeDiffComment && timeDiffComment <= POSTS_BUNDLE_TIME_DIFF
-      
+
       if (shouldBundle) {
         isBundleEdited = isBundleEdited || item.edited
         item.noInfo = true
@@ -133,6 +131,11 @@ class FeedComments extends React.Component {
         <div styleName="unread-splitter" key="unread-splitter">
           <span styleName="unread">New posts</span>
         </div>
+      }
+
+      if (idx === 0 && hasMoreComments) {
+        desktopBlocks.push(loadMoreTemplate)
+        mobileBlocks.push(loadMoreTemplate)
       }
 
       desktopBlocks.push(
@@ -194,13 +197,6 @@ class FeedComments extends React.Component {
             </div>
           ) : (
             <div>
-              {hasMoreComments &&
-                <div styleName="load-more" key="load-more">
-                  <a href="javascript:" onClick={ handleLoadMoreClick } styleName="load-btn">
-                    {isLoadingComments ? 'Loading...' : 'load earlier posts'}
-                  </a>
-                </div>
-              }
               {mobileBlocks}
             </div>
           ))}


### PR DESCRIPTION
In favour of #2128 

## Changes
- [x] Reposition `load earlier posts` button under time stamp
- [x] Abstract load more jsx template to reduce duplication

## Verify
- Load the project locally `npm start` 
- Login with `pshah_manager/topcoder123`
- Navigate to [http://localhost:3000/projects/6446](http://localhost:3000/projects/6446)
- Click on **Wireframes**
- Observe the position of `load earlier posts` button

<img width="786" alt="screen shot 2018-07-05 at 23 50 46" src="https://user-images.githubusercontent.com/6163988/42349932-a0fb25e8-80ae-11e8-9679-4aa465e3c0bb.png">
