### PR TITLE
Fix created post by non-member of the project breaks posts feed

### DIFF
--- a/src/components/Feed/FeedComments.jsx
+++ b/src/components/Feed/FeedComments.jsx
@@ -84,7 +84,7 @@ class FeedComments extends React.Component {
       const prevComment = comments[idx - 1]
       const prevCreatedAt = prevComment && moment(prevComment.createdAt)
       const isSameDay = prevCreatedAt && prevCreatedAt.isSame(createdAt, 'day')
-      const isSameAuthor = prevComment && prevComment.author.userId === item.author.userId
+      const isSameAuthor = _.has(prevComment, 'author.userId') && prevComment.author.userId === item.author.userId
       const isFirstUnread = prevComment && !prevComment.unread && item.unread
 
       const timeDiffComment = bundleCreatedAt && createdAt.diff(bundleCreatedAt)


### PR DESCRIPTION
This PR solves #1994

## Verify
- Load the project locally `npm start` 
- Login with `pshah_manager/topcoder123`
- Navigate to [http://localhost:3000/projects/4963](http://localhost:3000/projects/4963)
- post a comment and reload the page
- Leave the project
- post a comment and reload the page
- It does not crash like before now.