### PR TITLE
fix freezing project dashboard page on mobile resolutions

### DIFF
--- a/src/components/ProjectInfo/ProjectInfo.jsx
+++ b/src/components/ProjectInfo/ProjectInfo.jsx
@@ -61,7 +61,14 @@ class ProjectInfo extends Component {
                 project={project}
                 currentMemberRole={currentMemberRole}
                 duration={duration}
-                descLinesCount={matches ? 4 : Infinity}
+                descLinesCount={
+                  /* has to be not too big value here,
+                     because the plugin will make this number of iterations
+                     see https://github.com/ShinyChang/React-Text-Truncate/blob/master/src/TextTruncate.js#L133
+                     too big value may cause browser tab to freeze
+                   */
+                  matches ? 4 : 1000
+                }
                 onChangeStatus={onChangeStatus}
                 isSuperUser={isSuperUser}
                 showLink


### PR DESCRIPTION
### TLDR 

The fix is easy, clear and robust, safe for deploy.

### Details

The issue was with the package [react-text-truncate](https://github.com/ShinyChang/React-Text-Truncate) that we use to truncate too long project description on the dashboard with `read more` link.

For mobile resolutions, the truncate maximum lines has been set to `Infinity` which caused in some circumstances the infinite loop in the plugin, see https://github.com/ShinyChang/React-Text-Truncate/blob/master/src/TextTruncate.js#L133

I put `1000` as trancate maximum lines, feels like this is enogh for project descriptions to be shown fully without trancations.

NOTE, that even big finite values like `1 000 000` cause browser to freeze.