### PR TITLE
Hotfix/hidden on creation to PROD

### DIFF
--- a/src/projects/create/components/ProjectBasicDetailsForm.js
+++ b/src/projects/create/components/ProjectBasicDetailsForm.js
@@ -94,6 +94,7 @@ class ProjectBasicDetailsForm extends Component {
               // TODO we shoudl not update the props (section is coming from props)
               // further, it is not used for this component as we are not rendering spec screen section here
               validate={() => {}}//dummy
+              isCreation
             />
           </div>
           <div className="section-footer section-footer-spec">

--- a/src/projects/detail/components/SpecSection.jsx
+++ b/src/projects/detail/components/SpecSection.jsx
@@ -72,6 +72,7 @@ const SpecSection = props => {
     validate,
     sectionNumber,
     showHidden,
+    isCreation,
     addAttachment,
     updateAttachment,
     removeAttachment,
@@ -238,7 +239,12 @@ const SpecSection = props => {
         <p className="gray-text">
           {description}
         </p>
-        {subSections.filter((subSection) => showHidden || !subSection.hidden).map(renderSubSection)}
+        {subSections.filter((subSection) => (
+          // hide section marked with hiddenOnCreation during creation process
+          (!isCreation || !subSection.hiddenOnCreation) &&
+          // hide hidden section, unless we not force to show them
+          (showHidden || !subSection.hidden)
+        )).map(renderSubSection)}
       </div>
     </div>
   )
@@ -248,6 +254,7 @@ SpecSection.propTypes = {
   project: PropTypes.object.isRequired,
   sectionNumber: PropTypes.number.isRequired,
   showHidden: PropTypes.bool,
+  isCreation: PropTypes.bool,
   addAttachment: PropTypes.func.isRequired,
   updateAttachment: PropTypes.func.isRequired,
   removeAttachment: PropTypes.func.isRequired,


### PR DESCRIPTION
Hotfix which hides `hiddenOnCreate` questions during project creation wizard. For example, it hides file attachments. 

This is done by cherry-picking a commit from [dashboard-improvements](https://github.com/appirio-tech/connect-app/commits/feature/dashboard-improvements) branch.