### PR TITLE
issue #2352 - After adding a new phase, don't call loading timeline again as we get it during creation process

### DIFF
--- a/src/projects/actions/project.js
+++ b/src/projects/actions/project.js
@@ -20,7 +20,6 @@ import {
 import {
   createTimeline,
 } from '../../api/timelines'
-import { loadProductTimelineWithMilestones } from './productsTimelines'
 import {
   LOAD_PROJECT,
   CREATE_PROJECT,

--- a/src/projects/actions/project.js
+++ b/src/projects/actions/project.js
@@ -282,11 +282,6 @@ export function createProduct(project, productTemplate, phases) {
     return dispatch({
       type: CREATE_PROJECT_STAGE,
       payload: createProjectPhaseAndProduct(project, productTemplate, PROJECT_STATUS_DRAFT, startDate, endDate)
-        // after we created a new phase, we have to load timeline for its product
-        .then(({ product, project }) => {
-          return dispatch(loadProductTimelineWithMilestones(product.id))
-            .then(() => project)
-        })
     })
   }
 }
@@ -318,10 +313,11 @@ export function createProjectPhaseAndProduct(project, projectTemplate, status = 
       type: projectTemplate.key || projectTemplate.productKey,
     }).then((product) => {
       // we also wait until timeline is created as we will load it for the phase after creation
-      return createTimelineAndMilestoneForProduct(product, phase).then(() => ({
+      return createTimelineAndMilestoneForProduct(product, phase).then((timeline) => ({
         project,
         phase,
         product,
+        timeline,
       }))
     })
   })

--- a/src/projects/reducers/productsTimelines.js
+++ b/src/projects/reducers/productsTimelines.js
@@ -21,6 +21,7 @@ import {
   SUBMIT_FINAL_FIXES_REQUEST_PENDING,
   SUBMIT_FINAL_FIXES_REQUEST_SUCCESS,
   SUBMIT_FINAL_FIXES_REQUEST_FAILURE,
+  CREATE_PROJECT_STAGE_SUCCESS,
 } from '../../config/constants'
 import update from 'react-addons-update'
 
@@ -139,6 +140,28 @@ export const productsTimelines = (state=initialState, action) => {
         timeline: { $set: timeline },
         error: { $set: false },
       }
+    })
+  }
+
+  // when we create a product we also create a timeline and have to add it to the store
+  case CREATE_PROJECT_STAGE_SUCCESS: {
+    const timeline = payload.timeline
+    const productId = payload.product.id
+
+    // if there is timeline for the product
+    if (timeline) {
+      // sort milestones by order as server doesn't do it
+      timeline.milestones = _.sortBy(timeline.milestones, 'order')
+    }
+
+    return update(state, {
+      [productId]: {
+        $set: {
+          isLoading: false,
+          timeline,
+          error: false,
+        },
+      },
     })
   }
 

--- a/src/projects/reducers/project.js
+++ b/src/projects/reducers/project.js
@@ -240,12 +240,13 @@ export const projectState = function (state=initialState, action) {
   case CREATE_PROJECT_STAGE_SUCCESS:
   case CREATE_PROJECT_SUCCESS:
   case UPDATE_PROJECT_SUCCESS: {
+    const project = action.type === CREATE_PROJECT_STAGE_SUCCESS ? action.payload.project : action.payload
     // after loading project initially, we also load direct project
     // and add additional properties to the `project` object in LOAD_DIRECT_PROJECT_SUCCESS action
     // after updating project they will be lost, so here we restore them
     // TODO better don't add additional values to `project` object and keep additional values separately
     const restoredProject = {
-      ...action.payload,
+      ...project,
       budget: _.cloneDeep(state.project.budget),
       duration: _.cloneDeep(state.project.duration),
     }
@@ -255,7 +256,7 @@ export const projectState = function (state=initialState, action) {
       error: false,
       project: restoredProject,
       projectNonDirty: _.cloneDeep(restoredProject),
-      updateExisting: action.payload.updateExisting
+      updateExisting: project.updateExisting
     })
   }
 


### PR DESCRIPTION
issue #2352 - After adding a new phase, don't call loading timeline again as we get it during creation process