### PR TITLE
issue #2366 - Root post should not have delete post option

### DIFF
--- a/src/components/Feed/FeedComments.jsx
+++ b/src/components/Feed/FeedComments.jsx
@@ -301,7 +301,7 @@ class FeedComments extends React.Component {
           hasError={item.error}
           allMembers={allMembers}
           noInfo={item.noInfo}
-          canDelete={comments.length>1}
+          canDelete={idx !== 0}
         >
           <div dangerouslySetInnerHTML={{__html: markdownToHTML(item.content)}} />
         </Comment>


### PR DESCRIPTION
issue #2366 - Root post should not have delete post option

Done, so Delete post is not shown for root post.

I can make it look like disabled instead, but when user will click it, the dropdown will be closed anyway even it look disabled. I cannot prevent closing in current implementation as it uses `<DropdownItem>` component from `appirio-tech-react-components` which doesn't let us prevent closing `<Dropdown>` when we click it.
Also, styling of the disabled option would be done not the best and slightly hacky way because of the limitations of `<DropdownItem>` component from `appirio-tech-react-components`.

Please, let me know if you still want to keep it with disabled styles, even though when user will click it dropdown will be closed (delete action wouldn't be called, just closed dropdown).