### PR TITLE
issue #2362 - When we add links and `GET_NOTIFICATIONS_PENDING` action happens, it refreshes form

### DIFF
--- a/src/projects/detail/components/timeline/LinkList/LinkList.jsx
+++ b/src/projects/detail/components/timeline/LinkList/LinkList.jsx
@@ -21,7 +21,8 @@ class LinkList extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { isAddingLink } = this.state
-    if (isAddingLink && !nextProps.isUpdating) {
+    const { isUpdating } = this.props
+    if (isAddingLink && isUpdating && !nextProps.isUpdating) {
       this.closeAddForm()
     }
   }


### PR DESCRIPTION
issue #2362 - When we add links and `GET_NOTIFICATIONS_PENDING` action happens, it refreshes form