### PR TITLE
Issue #2185: Feed components are being re-rendered on typing

### DIFF
--- a/src/projects/detail/containers/FeedContainer.js
+++ b/src/projects/detail/containers/FeedContainer.js
@@ -77,6 +77,46 @@ class FeedView extends React.Component {
     this.init(this.props)
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    if (this.props.currentUser !== nextProps.currentUser) {
+      return true;
+    }
+    if (this.props.isLoading !== nextProps.isLoading) {
+      return true;
+    }
+    if (this.props.isCreatingFeed !== nextProps.isCreatingFeed) {
+      return true;
+    }
+    if (this.props.error !== nextProps.error) {
+      return true;
+    }
+    if (this.props.allMembers !== nextProps.allMembers) {
+      return true;
+    }
+    if (this.props.notifications !== nextProps.notifications) {
+      return true;
+    }
+    if (this.props.currentMemberRole !== nextProps.currentMemberRole) {
+      return true
+    }
+    if (this.props.project !== nextProps.project) {
+      return true
+    }
+    if (this.state.feeds.length !== nextState.feeds.length) {
+      return true;
+    }
+    if (this.state.showAll !== nextState.showAll) {
+      return true;
+    }
+    if (this.state.isNewPostMobileOpen !== nextState.isNewPostMobileOpen) {
+      return true;
+    }
+    if (this.state.fullscreenFeedId !== nextState.fullscreenFeedId) {
+      return true;
+    }
+    return false;
+  }
+
   componentWillReceiveProps(nextProps) {
     this.init(nextProps, this.props)
   }


### PR DESCRIPTION
#### Description 

Please see issue description here -> https://github.com/appirio-tech/connect-app/issues/2185

#### Changes

- Only re-render feed component changes when props or state has changed using `shouldComponentUpdate`

> Note: changes should improve all round re-rendering performance relating to feed component