### PR TITLE
login/signup ui update

### DIFF
--- a/src/projects/create/components/FillProjectDetails.js
+++ b/src/projects/create/components/FillProjectDetails.js
@@ -77,12 +77,6 @@ class FillProjectDetails extends Component  {
                   </div>
                 )}
               </div>
-              <div className="right-area">
-                <Sticky top={20}>
-                  <ProjectOutline project={ dirtyProject } projectTemplates={ projectTemplates } />
-                  <div className="right-area-footer">In 24 hours our project managers will contact you for more information and a detailed quote that accurately reflects your project needs.</div>
-                </Sticky>
-              </div>
             </div>
           </section>
         </div>

--- a/src/projects/create/components/FillProjectDetails.scss
+++ b/src/projects/create/components/FillProjectDetails.scss
@@ -25,6 +25,7 @@
       @extend .wizardHeadline;
 
       @media screen and (max-width: $screen-md - 1px) {
+        margin-top: 0;
         font-size: 20px;
         line-height: 24px;
         margin-bottom: 0;


### PR DESCRIPTION
1. when entering the pin, user is redirected to connect, without showing the `select solution` screen. user is redirected to connect root page, not the /new-project route (I see the redirect is implemented correctly in the select solution screen, but the user is redirected before that screen is shown)
2. when entering a wrong pin, spinner is shown and user can't enter new pin
3. user info should move to the right https://www.screencast.com/t/YLe3r9oN
4. Let's remove the project outline section in step 3
5. Implement the right sidebar in step 3 - the info will differ for each project type (App, Website, etc) and will come from the api - api call to /metadata endpoint has response.projectTypes field (used for rendering step2) and we'll add imageUrl, subtitle, description, brochureURL to each project type