### PR TITLE
issue #2543 - Profile links are linked to the DEV site on PROD site

### DIFF
--- a/src/components/User/UserTooltip.jsx
+++ b/src/components/User/UserTooltip.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Tooltip from 'appirio-tech-react-components/components/Tooltip/Tooltip'
 import Avatar from 'appirio-tech-react-components/components/Avatar/Avatar'
-import { DOMAIN } from '../../../config/constants'
+import { DOMAIN } from '../../config/constants'
 import { getAvatarResized } from '../../helpers/tcHelpers'
 
 require('./UserTooltip.scss')


### PR DESCRIPTION
Fixed #2543. 
Also tested by deploying a production version of the app locally.