### PR TITLE
issue #2522 - additional fixes

### DIFF
--- a/src/routes/settings/routes/notifications/components/NotificationSettingsForm.jsx
+++ b/src/routes/settings/routes/notifications/components/NotificationSettingsForm.jsx
@@ -146,18 +146,22 @@ const initSettings = (notInitedSettings) => {
       if (!notifications[type][serviceId]) {
         notifications[type][serviceId] = {}
       }
-      if (_.isUndefined(notifications[type][serviceId].enabled)) {
-        notifications[type][serviceId].enabled = 'yes'
-      }
-      if (_.isUndefined(notifications[type][serviceId].bundlePeriod)) {
-        notifications[type][serviceId].bundlePeriod = 'daily'
+
+      // for all messaging events, email notifications are off by default
+      if (serviceId === 'email' && _.includes(messagingTypes, type) && _.isUndefined(notifications[type][serviceId].enabled)) {
+        notifications[type][serviceId].enabled = 'no'
+        notifications[type][serviceId].bundlePeriod = ''
+
+      // for the rest of events, notifications are enabled by default and bundle period is set to 'daily'
+      } {
+        if (_.isUndefined(notifications[type][serviceId].enabled)) {
+          notifications[type][serviceId].enabled = 'yes'
+        }
+        if (_.isUndefined(notifications[type][serviceId].bundlePeriod)) {
+          notifications[type][serviceId].bundlePeriod = 'daily'
+        }
       }
     })
-
-    // for all messaging events, defaults emailBundling to off
-    if (_.includes(messagingTypes, type)) {
-      notifications[type]['email'].bundlePeriod = null
-    }
   })
 
   settings.notifications = notifications
@@ -182,7 +186,7 @@ class NotificationSettingsForm extends React.Component {
     // update values for all types of the topic
     topics[topicIndex].types.forEach((type) => {
       notifications[type].email.enabled = selectedOption.value === 'off' ? 'no' : 'yes'
-      notifications[type].email.bundlePeriod = selectedOption.value === 'off' ? null : selectedOption.value
+      notifications[type].email.bundlePeriod = selectedOption.value === 'off' ? '' : selectedOption.value
     })
 
     this.setState({

--- a/src/routes/settings/routes/notifications/components/NotificationSettingsForm.jsx
+++ b/src/routes/settings/routes/notifications/components/NotificationSettingsForm.jsx
@@ -147,17 +147,17 @@ const initSettings = (notInitedSettings) => {
         notifications[type][serviceId] = {}
       }
 
-      // for all messaging events, email notifications are off by default
-      if (serviceId === 'email' && _.includes(messagingTypes, type) && _.isUndefined(notifications[type][serviceId].enabled)) {
-        notifications[type][serviceId].enabled = 'no'
-        notifications[type][serviceId].bundlePeriod = ''
+      if (_.isUndefined(notifications[type][serviceId].enabled)) {
+        notifications[type][serviceId].enabled = 'yes'
+      }
 
-      // for the rest of events, notifications are enabled by default and bundle period is set to 'daily'
-      } {
-        if (_.isUndefined(notifications[type][serviceId].enabled)) {
-          notifications[type][serviceId].enabled = 'yes'
-        }
-        if (_.isUndefined(notifications[type][serviceId].bundlePeriod)) {
+      if (_.isUndefined(notifications[type][serviceId].bundlePeriod)) {
+        // for messageing related email notifications, by default bundle period is set to 'immediately'
+        if (serviceId === 'email' && _.includes(messagingTypes, type)) {
+          notifications[type][serviceId].bundlePeriod = 'immediately'
+
+        // for the rest of notifications by default bundle period is set to 'daily'
+        } else {
           notifications[type][serviceId].bundlePeriod = 'daily'
         }
       }


### PR DESCRIPTION
Additional fixes for issue #2522

@vikasrohit 
> btw, it seems we can not save `every 10 minutes` setting in notification settings now

I think the issue was not connected with `every 10 minutes` but with value for `bundlePeriod`, as a server doesn't accept `null`. Also, I've noticed not correct behaviour of default value for email settings of messaging notifications.

- fixed setting `bundlePeriod` to `off` by using an empty string `''` instead of `null`
- fixed default value for messaging notifications by email:
   - only for notifications related to messagin, if settings is not defined, then by default email notifications are `off` (bundlePeriod is '')
   - for the rest of notifications, default value is `daily`