### PR TITLE
Github issue#2707, Slider dots are off the slide rail in project edit scope form

### DIFF
--- a/src/projects/detail/components/EditProjectForm/EditProjectForm.scss
+++ b/src/projects/detail/components/EditProjectForm/EditProjectForm.scss
@@ -337,7 +337,7 @@
     }
 
     .SliderRadioGroup .rc-slider-mark {
-      position: relative;
+      // position: relative;
     }
 
   }


### PR DESCRIPTION
— Should be fixed