### PR TITLE
Github issue#2718, Unable to load messages for customers

### DIFF
--- a/src/projects/detail/components/timeline/Timeline/Timeline.jsx
+++ b/src/projects/detail/components/timeline/Timeline/Timeline.jsx
@@ -111,7 +111,7 @@ class Timeline extends React.Component {
             key="notifications-reader"
             id={`phase-${phaseId}-timeline-${timeline.id}`}
             criteria={[
-              { eventType: EVENT_TYPE.PROJECT_PLAN.TIMELINE_ADJUSTED, contents: { timeline: { id: timeline.id } } },
+              { eventType: EVENT_TYPE.PROJECT_PLAN.TIMELINE_ADJUSTED, contents: { updatedTimeline: { id: timeline.id } } },
               { eventType: EVENT_TYPE.PROJECT_PLAN.MILESTONE_ACTIVATED, contents: { timeline: { id: timeline.id } } },
               { eventType: EVENT_TYPE.PROJECT_PLAN.MILESTONE_COMPLETED, contents: { timeline: { id: timeline.id } } },
               { eventType: EVENT_TYPE.PROJECT_PLAN.WAITING_FOR_CUSTOMER_INPUT, contents: { timeline: { id: timeline.id } } },


### PR DESCRIPTION
- Proper fix, for #2718 , after identifying the root cause. Previous fix is also good to have for future unhandled situations.
RCA: the issue is reproducible when there is at least one active phase in the project and there is a notification for timeline adjustment for one of the phases. Error appears when app tries to auto expand the active phase cards on the dashboard. And reason for the issue not being reproducible as Admin or Manager role is that we don't auto expand the phase card for any non customer user.