### PR TITLE
Fixes #2770: ID field will no longer be rendered in TemplateForm

### DIFF
--- a/src/routes/metadata/components/TemplateForm.jsx
+++ b/src/routes/metadata/components/TemplateForm.jsx
@@ -92,6 +92,7 @@ class TemplateForm extends Component {
     const options = isDropdown ? field['options'] : []
     let value = field['value']
     let isReadOnly = false
+    let isHidden = false
     if (values && values[label]) {
       value = field['type'] === 'object' ? JSON.stringify(values[label]) : values[label]
       if (values.hasOwnProperty('id') && label === 'id') {
@@ -106,8 +107,12 @@ class TemplateForm extends Component {
       }
     }
 
+    if (label === 'id') {
+      isHidden = true
+    }
+
     return (
-      <div className="field" key={label}>
+      !isHidden && <div className="field" key={label}>
         <div className="label">{`${!isCheckbox ? label : ''}`}</div>
         {
           isTextBox && (


### PR DESCRIPTION
- [x] ID field will no longer be rendered in the TemplateForm, so that user will not see it and/or will not need to input any `id` information