### PR TITLE
Feature/reduce number of member search calls

### DIFF
--- a/src/projects/actions/phasesTopics.js
+++ b/src/projects/actions/phasesTopics.js
@@ -52,9 +52,8 @@ const getPhaseTopicWithoutMembers = (dispatch, projectId, phaseId, tag) => {
       type: LOAD_PHASE_FEED,
       payload: getTopicsWithComments('project', `${projectId}`, `phase#${phaseId}`, false),
       meta: { tag, phaseId }
-    })
-    .then((resp) => resolve(resp))
-    .catch(err => reject(err))
+    }).then((resp) => resolve(resp))
+      .catch(err => reject(err))
   })
 }
 

--- a/src/projects/actions/phasesTopics.js
+++ b/src/projects/actions/phasesTopics.js
@@ -22,6 +22,19 @@ import {
 import { loadMembers } from '../../actions/members'
 import { EventTypes } from 'redux-segment'
 
+export function loadFeedsForPhases(projectId, phases, dispatch) {
+
+  const tag = PROJECT_FEED_TYPE_PHASE
+  return Promise.all(
+    phases.map((phase) => getPhaseTopicWithoutMembers(dispatch, projectId, phase.id, tag))
+  ).then((responses) => {
+    return _.map(responses, (resp) => ({
+      topics: _.get(resp, 'value.topics'),
+      phaseId: _.get(resp, 'action.meta.phaseId')
+    }))
+  })
+}
+
 export function loadPhaseFeed(projectId, phaseId) {
   const tag = PROJECT_FEED_TYPE_PHASE
   return (dispatch) => {
@@ -31,6 +44,18 @@ export function loadPhaseFeed(projectId, phaseId) {
       meta: { tag, phaseId }
     })
   }
+}
+
+const getPhaseTopicWithoutMembers = (dispatch, projectId, phaseId, tag) => {
+  return new Promise((resolve, reject) => {
+    return dispatch({
+      type: LOAD_PHASE_FEED,
+      payload: getTopicsWithComments('project', `${projectId}`, `phase#${phaseId}`, false),
+      meta: { tag, phaseId }
+    })
+    .then((resp) => resolve(resp))
+    .catch(err => reject(err))
+  })
 }
 
 const getPhaseTopicWithMember = (dispatch, projectId, phaseId, tag) => {

--- a/src/projects/actions/projectDashboard.js
+++ b/src/projects/actions/projectDashboard.js
@@ -3,7 +3,13 @@ import { loadMembers } from '../../actions/members'
 import { loadProject, loadProjectInvite, loadDirectProjectData, loadProjectPhasesWithProducts } from './project'
 import { loadProjectsMetadata } from '../../actions/templates'
 import { loadProductTimelineWithMilestones } from './productsTimelines'
-import { LOAD_PROJECT_DASHBOARD, LOAD_ADDITIONAL_PROJECT_DATA } from '../../config/constants'
+import { loadFeedsForPhases } from './phasesTopics'
+import { LOAD_PROJECT_DASHBOARD,
+  LOAD_ADDITIONAL_PROJECT_DATA,
+  DISCOURSE_BOT_USERID,
+  CODER_BOT_USERID,
+  TC_SYSTEM_USERID
+} from '../../config/constants'
 
 /**
  * Load all project data to paint the dashboard
@@ -39,11 +45,26 @@ const getDashboardData = (dispatch, getState, projectId, isOnlyLoadProjectInfo) 
       if (project.version === 'v3') {
         promises.push(
           dispatch(loadProjectPhasesWithProducts(projectId))
-            .then(({ value: phases }) =>
-            // load timelines for phase products here together with all dashboard data
-            // as we need to know timeline data not only inside timeline container
+            .then(({ value: phases }) => {
+              loadFeedsForPhases(projectId, phases, dispatch)
+              .then((phaseFeeds) => {
+                console.log(phaseFeeds)
+                let userIds = []
+                _.forEach(phaseFeeds, phaseFeed => {
+                  userIds = _.union(userIds, _.map(phaseFeed.topics, 'userId'))
+                  _.forEach(phaseFeed.topics, topic => {
+                    userIds = _.union(userIds, _.map(topic.posts, 'userId'))
+                  })
+                  // this is to remove any nulls from the list (dev had some bad data)
+                  _.remove(userIds, i => !i || [DISCOURSE_BOT_USERID, CODER_BOT_USERID, TC_SYSTEM_USERID].indexOf(i) > -1)
+                });
+
+                dispatch(loadMembers(userIds))
+              })
+              // load timelines for phase products here together with all dashboard data
+              // as we need to know timeline data not only inside timeline container
               loadTimelinesForPhasesProducts(phases, dispatch)
-            )
+            })
         )
       }
 

--- a/src/projects/actions/projectDashboard.js
+++ b/src/projects/actions/projectDashboard.js
@@ -47,20 +47,20 @@ const getDashboardData = (dispatch, getState, projectId, isOnlyLoadProjectInfo) 
           dispatch(loadProjectPhasesWithProducts(projectId))
             .then(({ value: phases }) => {
               loadFeedsForPhases(projectId, phases, dispatch)
-              .then((phaseFeeds) => {
-                console.log(phaseFeeds)
-                let userIds = []
-                _.forEach(phaseFeeds, phaseFeed => {
-                  userIds = _.union(userIds, _.map(phaseFeed.topics, 'userId'))
-                  _.forEach(phaseFeed.topics, topic => {
-                    userIds = _.union(userIds, _.map(topic.posts, 'userId'))
+                .then((phaseFeeds) => {
+                  console.log(phaseFeeds)
+                  let userIds = []
+                  _.forEach(phaseFeeds, phaseFeed => {
+                    userIds = _.union(userIds, _.map(phaseFeed.topics, 'userId'))
+                    _.forEach(phaseFeed.topics, topic => {
+                      userIds = _.union(userIds, _.map(topic.posts, 'userId'))
+                    })
+                    // this is to remove any nulls from the list (dev had some bad data)
+                    _.remove(userIds, i => !i || [DISCOURSE_BOT_USERID, CODER_BOT_USERID, TC_SYSTEM_USERID].indexOf(i) > -1)
                   })
-                  // this is to remove any nulls from the list (dev had some bad data)
-                  _.remove(userIds, i => !i || [DISCOURSE_BOT_USERID, CODER_BOT_USERID, TC_SYSTEM_USERID].indexOf(i) > -1)
-                });
 
-                dispatch(loadMembers(userIds))
-              })
+                  dispatch(loadMembers(userIds))
+                })
               // load timelines for phase products here together with all dashboard data
               // as we need to know timeline data not only inside timeline container
               loadTimelinesForPhasesProducts(phases, dispatch)


### PR DESCRIPTION
One efforts towards resolving #2815 

fyi @maxceem @RishiRajSahu, originally I thought of keeping it as hotfix because I was seeing very slow response on the production, however, it turned out that caching was not working for cloudfront on production and these extra calls for _search were not introduced in our last release 2.4.9. So, merging the changes as regular feature, so that we can test it out more in dev env.
In case, we see the need of this on production before our next release, we will cherry pick the changes to the master hotfix.