### PR TITLE
Github issue#2921, Cannot read property 'title' of undefined

### DIFF
--- a/src/components/TeamManagement/TopcoderManagementDialog.js
+++ b/src/components/TeamManagement/TopcoderManagementDialog.js
@@ -172,7 +172,7 @@ class TopcoderManagementDialog extends React.Component {
               const lastName = _.get(member, 'lastName', '')
               let userFullName = `${firstName} ${lastName}`
               userFullName = userFullName.trim().length > 0 ? userFullName : 'Connect user'
-              const role = _.find(this.roles, r => r.value === member.role).title
+              const role = _.get(_.find(this.roles, r => r.value === member.role), 'title')
               return (
                 <div
                   key={i}


### PR DESCRIPTION
— Should be fixed. Root cause is that some how a customer role user is being rendered in the topcoder team dialog. However, this fix should allow graceful failing in such situations as well.