### PR TITLE
Form JSON Schemas

### DIFF
--- a/src/config/form-schemas/form-v1.json
+++ b/src/config/form-schemas/form-v1.json
@@ -1,0 +1,309 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/appirio-tech/connect-app/master/src/config/form-schemas/form-v1.json",
+  "type": "object",
+  "title": "Project form schema v1",
+  "properties": {
+    "sections": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/sectionDef"
+      }
+    }
+  },
+  "required": [
+    "sections"
+  ],
+  "definitions": {
+    "sectionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "hideTitle": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        },
+        "subSections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/subSectionDef"
+          }
+        }
+      }
+    },
+    "subSectionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "validationError": {
+          "type": "string"
+        },
+        "fieldName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "hideTitle": {
+          "type": "boolean"
+        },
+        "hiddenOnCreation": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "files",
+            "notes",
+            "project-name",
+            "questions"
+          ]
+        },
+        "questions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/questionDef"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "questions"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "questions"
+        ]
+      }
+    },
+    "questionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "description",
+        "type"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tiled-radio-group",
+            "radio-group",
+            "checkbox-group",
+            "textbox",
+            "slide-radiogroup",
+            "select-dropdown"
+          ]
+        },
+        "validations": {
+          "type": "string"
+        },
+        "validationErrors": {
+          "type": "object"
+        },
+        "validationError": {
+          "type": "string"
+        },
+        "fieldName": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tiled-radio-group"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "options"
+            ],
+            "properties": {
+              "options": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/tiledOptionDef"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "checkbox-group",
+                  "radio-group"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "options"
+            ],
+            "properties": {
+              "options": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/simpleOptionDef"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "slide-radiogroup",
+                  "select-dropdown"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "options"
+            ],
+            "properties": {
+              "options": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/valuePairOptionDef"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "valuePairOptionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "title"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "simpleOptionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "label"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "tiledOptionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "title",
+        "icon",
+        "iconOptions",
+        "desc"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "iconOptions": {
+          "type": "object",
+          "properties": {
+            "fill": {
+              "type": "string"
+            },
+            "number": {
+              "type": "string"
+            }
+          }
+        },
+        "desc": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/src/config/form-schemas/form-v2.json
+++ b/src/config/form-schemas/form-v2.json
@@ -1,0 +1,343 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/appirio-tech/connect-app/master/src/config/form-schemas/form-v2.json",
+  "type": "object",
+  "title": "Project form schema v2",
+  "properties": {
+    "sections": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/sectionDef"
+      }
+    }
+  },
+  "required": [
+    "sections"
+  ],
+  "definitions": {
+    "sectionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "statusText": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "hideTitle": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "wizard": {
+          "$ref": "#/definitions/wizardDef"
+        },
+        "hiddenOnEdit": {
+          "type": "boolean"
+        },
+        "hideFormHeader": {
+          "type": "boolean"
+        },
+        "nextButtonText": {
+          "type": "string"
+        },
+        "footer": {
+          "$ref": "#/definitions/footerDef"
+        },
+        "subSections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/subSectionDef"
+          }
+        }
+      }
+    },
+    "subSectionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "tabs",
+            "questions",
+            "notes",
+            "message",
+            "files",
+            "screens",
+            "project-name",
+            "project-name-advanced",
+            "portal"
+          ]
+        },
+        "hideTitle": {
+          "type": "boolean"
+        },
+        "theme": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "questions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/questionDef"
+          }
+        },
+        "wizard": {
+          "$ref": "#/definitions/wizardDef"
+        },
+        "condition": {
+          "type": "string"
+        },
+        "fieldName": {
+          "type": "string"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/subSectionContentDef"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "questions"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "questions"
+        ]
+      }
+    },
+    "questionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "icon": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fieldName": {
+          "type": "string"
+        },
+        "theme": {
+          "type": "string"
+        },
+        "condition": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "validations": {
+          "type": "string"
+        },
+        "validationError": {
+          "type": "string"
+        },
+        "validationErrors": {
+          "type": "object"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "hiddenOnEdit": {
+          "type": "boolean"
+        },
+        "content": {
+          "type": "string"
+        },
+        "summaryTitle": {
+          "type": "string"
+        },
+        "help": {
+          "$ref": "#/definitions/helpDef"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/optionDef"
+          }
+        },
+        "affectsQuickQuote": {
+          "type": "boolean"
+        },
+        "deliverables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/deliverableDef"
+          }
+        },
+        "summaryMode": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "see-attached-textbox",
+            "textinput",
+            "numberinput",
+            "numberinputpositive",
+            "textbox",
+            "radio-group",
+            "tiled-radio-group",
+            "see-attached-tiled-radio-group",
+            "checkbox-group",
+            "checkbox",
+            "tiled-checkbox-group",
+            "see-attached-features",
+            "colors",
+            "select-dropdown",
+            "slide-radiogroup",
+            "add-ons",
+            "estimation",
+            "static"
+          ]
+        }
+      }
+    },
+    "optionDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "summaryLabel": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "autoSelectCondition": {
+          "type": "string"
+        },
+        "disableCondition": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "condition": {
+          "type": "string"
+        }
+      }
+    },
+    "helpDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "linkTitle",
+        "title",
+        "content"
+      ],
+      "properties": {
+        "linkTitle": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        }
+      }
+    },
+    "wizardDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "previousStepVisibility": {
+          "type": "string",
+          "enum": [
+            "write",
+            "readOptimized",
+            "none"
+          ]
+        }
+      }
+    },
+    "footerDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "content": {
+          "type": "string"
+        }
+      }
+    },
+    "deliverableDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title",
+        "duration",
+        "enableCondition",
+        "deliverableKey"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "number"
+        },
+        "enableCondition": {
+          "type": "string"
+        },
+        "deliverableKey": {
+          "type": "string"
+        }
+      }
+    },
+    "subSectionContentDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sectionIndex": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Form JSON schemas which cover two types of form templates old ones and the new one with the support of wizard.

I suggest keeping them inside Connect App as later we can use them in the JSON editor to validate templates during editing.