### PR TITLE
skip empty addons

### DIFF
--- a/src/helpers/wizardHelper.js
+++ b/src/helpers/wizardHelper.js
@@ -315,11 +315,12 @@ export const forEachNode = (template, iteratee, iterateSublevelCondition) => {
  *
  * @param {Object}  template            raw template
  * @param {Object}  project             project data (non-flat)
+ * @param {Array}   productTemplates    product templates
  * @param {Object}  incompleteWizard    incomplete wizard props
  *
  * @returns {Object} initialized template
  */
-export const initWizard = (template, project, incompleteWizard) => {
+export const initWizard = (template, project, productTemplates, incompleteWizard) => {
   let wizardTemplate = _.cloneDeep(template)
   const isWizardMode = _.get(template, 'wizard.enabled')
   // try to get the step where we left the wizard
@@ -362,7 +363,7 @@ export const initWizard = (template, project, incompleteWizard) => {
       nodeObject.deliverables.forEach((deliverable) => {
         if (deliverable.enableCondition) {
           deliverable.enableCondition = populatePreparedConditions(deliverable.enableCondition, preparedConditions)
-        }        
+        }
       })
     }
 
@@ -380,7 +381,7 @@ export const initWizard = (template, project, incompleteWizard) => {
     }
   })
 
-  const updateResult = updateNodesByConditions(wizardTemplate, project)
+  const updateResult = updateNodesByConditions(wizardTemplate, project, productTemplates)
   wizardTemplate = updateResult.updatedTemplate
 
   // initialize wizard mode
@@ -407,7 +408,7 @@ export const initWizard = (template, project, incompleteWizard) => {
 
     currentWizardStep = lastWizardStep || currentWizardStep
   }
-
+  console.warn('wizardTemplate', wizardTemplate)
   return {
     template: wizardTemplate,
     currentWizardStep,
@@ -890,10 +891,11 @@ const getNodeChildren = (template, node) => {
  *
  * @param {Object} template template
  * @param {Object} project  data to evaluate question conditions
+ * @param {Array} productTemplates  product templates
  *
  * @returns {Object} updated template
  */
-export const updateNodesByConditions = (template, project) => {
+export const updateNodesByConditions = (template, project, productTemplates) => {
   let updatedTemplate = template
   let hidedSomeNodes = false
   let updatedSomeNodes = false
@@ -936,6 +938,34 @@ export const updateNodesByConditions = (template, project) => {
         updatedSomeNodes: false,
       }
     }
+  }
+
+  // TODO at the moment we use section ids for this logic which binds the logic to templates
+  //      making the common logic would be much more complicated here, so at the moment we use this solution
+  //      in the future we should re-implement it without using id to support it more general case if posssible
+  const summaryIntermediateSection = updatedTemplate.sections.find(section => section.id === 'summary-intermediate')
+  const addOnSection =  updatedTemplate.sections.find(section => section.id === 'add-ons')
+  let hasActiveAddOnSection = false
+
+  addOnSection.subSections.forEach(subSection => {
+    subSection.questions.forEach(q => {
+      // skip add-ons step if no product templates found
+      const doesNotHaveAddOns = !_.some(productTemplates, { category: q.category, isAddOn: true })
+      if (q.type === 'add-ons' && doesNotHaveAddOns) {
+        q.__wizard.hiddenByCondition = true
+      }
+
+      if (!_.get(q, '__wizard.hiddenByCondition')){
+        hasActiveAddOnSection = true
+      }
+    })
+  })
+
+  // skip intermediate summary step if no add-ons step found
+  if (!hasActiveAddOnSection) {
+    summaryIntermediateSection.__wizard.hiddenByCondition = true
+  } else {
+    delete summaryIntermediateSection.__wizard.hiddenByCondition
   }
 
   return {

--- a/src/helpers/wizardHelper.js
+++ b/src/helpers/wizardHelper.js
@@ -408,7 +408,7 @@ export const initWizard = (template, project, productTemplates, incompleteWizard
 
     currentWizardStep = lastWizardStep || currentWizardStep
   }
-  console.warn('wizardTemplate', wizardTemplate)
+  
   return {
     template: wizardTemplate,
     currentWizardStep,

--- a/src/projects/create/components/ProjectBasicDetailsForm.js
+++ b/src/projects/create/components/ProjectBasicDetailsForm.js
@@ -55,7 +55,7 @@ class ProjectBasicDetailsForm extends Component {
       prevWizardStep,
       isWizardMode,
       hasDependantFields,
-    } = initWizard(props.template, props.project, incompleteWizard)
+    } = initWizard(props.template, props.project, props.productTemplates, incompleteWizard)
 
     this.state = {
       template,
@@ -95,7 +95,7 @@ class ProjectBasicDetailsForm extends Component {
     // updating template from template editor
     if(nextProps.shouldUpdateTemplate && template !== nextProps.template) {
 
-      const state = initWizard(nextProps.template, nextProps.project, null, true)
+      const state = initWizard(nextProps.template, nextProps.project, nextProps.productTemplates, null)
 
       template = state.template
       hasDependantFields = state.hasDependantFields
@@ -111,7 +111,7 @@ class ProjectBasicDetailsForm extends Component {
         updatedTemplate,
         hidedSomeNodes,
         updatedSomeNodes,
-      } = updateNodesByConditions(template, nextProps.dirtyProject)
+      } = updateNodesByConditions(template, nextProps.dirtyProject, nextProps.productTemplates)
 
       if (updatedSomeNodes) {
         this.setState({

--- a/src/projects/detail/components/EditProjectForm/EditProjectForm.jsx
+++ b/src/projects/detail/components/EditProjectForm/EditProjectForm.jsx
@@ -75,7 +75,7 @@ class EditProjectForm extends Component {
     const {
       template,
       hasDependantFields,
-    } = initWizard(props.template, props.project, null, true)
+    } = initWizard(props.template, props.project, props.productTemplates, null)
 
     this.state = {
       template,
@@ -98,7 +98,7 @@ class EditProjectForm extends Component {
     // updating template from template editor
     if(nextProps.shouldUpdateTemplate && template !== nextProps.template) {
 
-      const state = initWizard(nextProps.template, nextProps.project, null, true)
+      const state = initWizard(nextProps.template, nextProps.project, nextProps.productTemplates, null)
 
       template = state.template
       hasDependantFields = state.hasDependantFields
@@ -144,7 +144,7 @@ class EditProjectForm extends Component {
         updatedTemplate,
         updatedSomeNodes,
         hidedSomeNodes
-      } = updateNodesByConditions(template, nextProps.project)
+      } = updateNodesByConditions(template, nextProps.project, nextProps.productTemplates)
 
       if (updatedSomeNodes) {
         this.setState({


### PR DESCRIPTION
> can we by pass the specific deliverable addon section when there is no addon for that particular deliverable e.g. as of now Deployment does not have any add on, we want to skip directly to the final summary screen when user selects only the Deployment as deliverable and answers all required question i.e. we want to skip the intermediate summary screen and the the empty screen which asks for selecting addons.

This is done. At the moment the solution uses section IDs to detect intermediate section and add-ons section:
```
section.id === 'summary-intermediate'
section.id === 'add-ons'
```
This binds the logic to the particular template. But anyway it looks like there is no other way to describe this logic or we should introduce some additional properties to define these sections. 

I think we can use this solution until we get some additional requirements or other templates examples. We should use these IDs for now for these two sections.