### PR TITLE
Github issue#2934, Newest message displays at the top of thread

### DIFF
--- a/src/components/Feed/FeedComments.jsx
+++ b/src/components/Feed/FeedComments.jsx
@@ -373,16 +373,6 @@ class FeedComments extends React.Component {
         <MediaQuery minWidth={SCREEN_BREAKPOINT_MD}>
           {(matches) => (matches ? (
             <div>
-              <div styleName="comments">
-                {commentRows}
-                {hasMoreComments &&
-                  <div styleName="load-more" key="load-more">
-                    <a href="javascript:" onClick={ handleLoadMoreClick } styleName="load-btn">
-                      {isLoadingComments ? 'Loading...' : 'load earlier posts'}
-                    </a>
-                  </div>
-                }
-              </div>
               {allowComments &&
                 <div styleName="add-comment" key="add-comment">
                   <AddComment
@@ -398,6 +388,16 @@ class FeedComments extends React.Component {
                   />
                 </div>
               }
+              <div styleName="comments">
+                {commentRows}
+                {hasMoreComments &&
+                  <div styleName="load-more" key="load-more">
+                    <a href="javascript:" onClick={ handleLoadMoreClick } styleName="load-btn">
+                      {isLoadingComments ? 'Loading...' : 'load earlier posts'}
+                    </a>
+                  </div>
+                }
+              </div>
             </div>
           ) : (
             <div>


### PR DESCRIPTION
- Moving Add Post text box above the comments to match with the new reversed order of posts

fyi @maxceem @RishiRajSahu 