### PR TITLE
fix draftjs link editor opening autopopover without title

### DIFF
--- a/src/components/RichTextArea/LinkPlugin/EditLinkPopover/EditLinkPopover.jsx
+++ b/src/components/RichTextArea/LinkPlugin/EditLinkPopover/EditLinkPopover.jsx
@@ -140,8 +140,8 @@ export default class EditLink extends React.Component {
     this.onDocClick = this.onDocClick.bind(this)
   }
 
-  componentDidMount(props = this.props) {
-    const { editing, text, url, entityKey } = props
+  componentDidMount() {
+    const { editing, text, url, entityKey } = this.props
 
     this.currentlyEditingEntity = entityKey
     this.setState({


### PR DESCRIPTION
Fix issue mentioned in https://github.com/appirio-tech/connect-app/issues/2937#issuecomment-492094038 