### PR TITLE
Github issue#3090, Direct Invited Just-Registered Users to All Projects Dashboard

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -513,8 +513,7 @@ export const PHASE_STATUS = [
 
 // this defines default criteria to filter projects for projects list
 export const PROJECT_LIST_DEFAULT_CRITERIA = {
-  sort: 'updatedAt desc',
-  status: PROJECT_STATUS_ACTIVE
+  sort: 'updatedAt desc'
 }
 
 export const NOTIFICATION_TYPE = {


### PR DESCRIPTION
— Fixed, as per discussion in team call, now we would redirect all users to `All Projects` by default.