### PR TITLE
Feature/skills question api and custom skills

### DIFF
--- a/src/projects/detail/components/Accordion/Accordion.jsx
+++ b/src/projects/detail/components/Accordion/Accordion.jsx
@@ -34,7 +34,7 @@ const TYPE = {
  * @returns {Function} valueMapper
  */
 const createValueMapper = (valuesMap) => (value) => (
-  valuesMap[value] && (valuesMap[value].summaryLabel || valuesMap[value].label || valuesMap[value].title || valuesMap[value].name)
+  valuesMap[value] && (valuesMap[value].summaryLabel || valuesMap[value].label || valuesMap[value].title)
 )
 
 class Accordion extends React.Component {
@@ -103,7 +103,7 @@ class Accordion extends React.Component {
     const { type, options } = this.props
     const { value } = this.state
 
-    const valuesMap = _.keyBy(options, TYPE.SKILLS === type ? 'id' : 'value')
+    const valuesMap = _.keyBy(options, 'value')
     const mapValue = createValueMapper(valuesMap)
 
     if (!value) {

--- a/src/projects/detail/components/Accordion/Accordion.jsx
+++ b/src/projects/detail/components/Accordion/Accordion.jsx
@@ -114,7 +114,7 @@ class Accordion extends React.Component {
     case TYPE.CHECKBOX_GROUP: return value.map(mapValue).join(', ')
     case TYPE.RADIO_GROUP: return mapValue(value)
     case TYPE.ADD_ONS: return `${value.length} selected`
-    case TYPE.SKILLS: return value.map(mapValue).join(', ')
+    case TYPE.SKILLS: return `${value.length} selected`
     default: return value
     }
   }

--- a/src/projects/detail/components/Accordion/Accordion.jsx
+++ b/src/projects/detail/components/Accordion/Accordion.jsx
@@ -34,7 +34,7 @@ const TYPE = {
  * @returns {Function} valueMapper
  */
 const createValueMapper = (valuesMap) => (value) => (
-  valuesMap[value] && (valuesMap[value].summaryLabel || valuesMap[value].label || valuesMap[value].title)
+  valuesMap[value] && (valuesMap[value].summaryLabel || valuesMap[value].label || valuesMap[value].title || valuesMap[value].name)
 )
 
 class Accordion extends React.Component {
@@ -103,7 +103,7 @@ class Accordion extends React.Component {
     const { type, options } = this.props
     const { value } = this.state
 
-    const valuesMap = _.keyBy(options, 'value')
+    const valuesMap = _.keyBy(options, TYPE.SKILLS === type ? 'id' : 'value')
     const mapValue = createValueMapper(valuesMap)
 
     if (!value) {

--- a/src/projects/detail/components/SkillsQuestion/SkillsCheckboxGroup.jsx
+++ b/src/projects/detail/components/SkillsQuestion/SkillsCheckboxGroup.jsx
@@ -14,7 +14,7 @@ class SkillsCheckboxGroup extends Component {
     const value = []
     this.props.options.forEach((option, key) => {
       if (this['element-' + key].checked) {
-        value.push(option.value)
+        value.push(option)
       }
     })
     this.props.setValue(value)
@@ -26,7 +26,7 @@ class SkillsCheckboxGroup extends Component {
     const curValue = getValue() || []
 
     const renderOption = (cb, key) => {
-      const checked = curValue.includes(cb.value)
+      const checked = _.some(curValue, cb)
       const checkboxDisabled = cb.disabled || disabled
       const rClass = cn('tc-checkbox-group-item', { disabled, selected: checked })
       const id = name+'-opt-'+key
@@ -45,7 +45,7 @@ class SkillsCheckboxGroup extends Component {
             />
             <label htmlFor={id}/>
           </div>
-          <label htmlFor={id}>{cb.title}</label>
+          <label htmlFor={id}>{cb.name}</label>
           {
             cb.description && checked && <div styleName="item-description"> {cb.description} </div>
           }

--- a/src/projects/detail/components/SkillsQuestion/SkillsCheckboxGroup.jsx
+++ b/src/projects/detail/components/SkillsQuestion/SkillsCheckboxGroup.jsx
@@ -45,7 +45,7 @@ class SkillsCheckboxGroup extends Component {
             />
             <label htmlFor={id}/>
           </div>
-          <label htmlFor={id}>{cb.title}</label>
+          <label htmlFor={id}>{cb.title || cb.name}</label>
           {
             cb.description && checked && <div styleName="item-description"> {cb.description} </div>
           }

--- a/src/projects/detail/components/SkillsQuestion/SkillsCheckboxGroup.jsx
+++ b/src/projects/detail/components/SkillsQuestion/SkillsCheckboxGroup.jsx
@@ -45,7 +45,7 @@ class SkillsCheckboxGroup extends Component {
             />
             <label htmlFor={id}/>
           </div>
-          <label htmlFor={id}>{cb.title || cb.name}</label>
+          <label htmlFor={id}>{cb.title}</label>
           {
             cb.description && checked && <div styleName="item-description"> {cb.description} </div>
           }

--- a/src/projects/detail/components/SkillsQuestion/SkillsQuestion.jsx
+++ b/src/projects/detail/components/SkillsQuestion/SkillsQuestion.jsx
@@ -23,7 +23,10 @@ class SkillsQuestion extends React.Component {
         const options = _.get(resp.data, 'result.content', {})
         this.setState({ options })
         if (onSkillsLoaded) {
-          onSkillsLoaded(options)
+          onSkillsLoaded(options.map((option) => ({
+            title: option.name,
+            value: option.id,
+          })))
         }
       })
   }
@@ -88,9 +91,12 @@ class SkillsQuestion extends React.Component {
     const errorMessage = getErrorMessage() || validationError
 
     const checkboxGroupOptions = availableOptions.filter(option => frequentSkills.indexOf(option.id) > -1).map(
-      option => Object.assign({}, option, { value: option.id })
+      option => ({
+        title: option.name,
+        value: option.id,
+      })
     )
-    const checkboxGroupValues = currentValues.filter(val => _.some(checkboxGroupOptions, option => option.id === val ))
+    const checkboxGroupValues = currentValues.filter(val => _.some(checkboxGroupOptions, option => option.value === val ))
     const selectGroupOptions =
       availableOptions.filter(option => frequentSkills.indexOf(option.id) === -1).map(
         option => Object.assign({}, option, { value: option.id }))

--- a/src/projects/detail/components/SpecQuestions.jsx
+++ b/src/projects/detail/components/SpecQuestions.jsx
@@ -72,25 +72,35 @@ const buildAddonsOptions = (q, productTemplates, productCategories) => {
 }
 
 // { isRequired, represents the overall questions section's compulsion, is also available}
-const SpecQuestions = ({
-  questions,
-  layout,
-  additionalClass,
-  project,
-  template,
-  currentWizardStep,
-  dirtyProject,
-  resetFeatures,
-  showFeaturesDialog,
-  showHidden,
-  isProjectDirty,
-  productTemplates,
-  productCategories,
-  isCreation,
-}) => {
-  const currentProjectData = isProjectDirty ? dirtyProject : project
+class SpecQuestions extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      skillOptions: []
+    }
+    this.handleSkillsLoaded = this.handleSkillsLoaded.bind(this)
+    this.renderQ = this.renderQ.bind(this)
+  }
 
-  const renderQ = (q, index) => {
+  handleSkillsLoaded(skills) {
+    this.setState({ skillOptions: skills })
+  }
+
+
+  renderQ(q, index) {
+    const {
+      project,
+      template,
+      currentWizardStep,
+      dirtyProject,
+      resetFeatures,
+      showFeaturesDialog,
+      isProjectDirty,
+      productTemplates,
+      productCategories,
+    } = this.props
+    const currentProjectData = isProjectDirty ? dirtyProject : project
+
     const elemProps = {
       name: q.fieldName,
       label: q.label,
@@ -303,9 +313,11 @@ const SpecQuestions = ({
       ChildElem = SkillsQuestion
       _.assign(elemProps, {
         currentProjectData,
-        options: q.skills,
-        skillsCategoriesField: q.skillsCategoriesField,
-        fieldName: q.fieldName
+        categoriesField: q.skills.categoriesField,
+        categoriesMapping: q.skills.categoriesMapping,
+        frequentSkills: q.skills.frequent,
+        fieldName: q.fieldName,
+        onSkillsLoaded: this.handleSkillsLoaded
       })
       break
     default:
@@ -344,37 +356,54 @@ const SpecQuestions = ({
     )
   }
 
-  return (
-    <SpecQuestionList layout={layout} additionalClass={additionalClass}>
-      {questions.map(question => ({
-        ...question,
-        visibilityForRendering: isCreation ? getVisibilityForRendering(template, question, currentWizardStep) : STEP_VISIBILITY.READ_OPTIMIZED,
-        stepState: isCreation ? geStepState(question, currentWizardStep) : STEP_STATE.PREV
-      })).filter((question) =>
-        // hide if we are in a wizard mode and question is hidden for now
-        (question.visibilityForRendering !== STEP_VISIBILITY.NONE) &&
-        // hide if question is hidden by condition
-        (!_.get(question, '__wizard.hiddenByCondition')) &&
-        // hide hidden questions, unless we not force to show them
-        (showHidden || !question.hidden) &&
-        // hide question in edit mode if configured
-        (isCreation || !question.hiddenOnEdit)
-      ).map((q, index) => (
-        _.includes(['checkbox-group', 'radio-group', 'add-ons', 'textinput', 'textbox', 'numberinput', 'skills'], q.type) && q.visibilityForRendering === STEP_VISIBILITY.READ_OPTIMIZED ? (
-          <Accordion
-            key={q.fieldName || `accordion-${index}`}
-            title={q.summaryTitle || q.title}
-            type={q.type}
-            options={q.options || q.skills || buildAddonsOptions(q, productTemplates, productCategories)}
-          >
-            {renderQ(q, index)}
-          </Accordion>
-        ) : (
-          renderQ(q, index)
-        )
-      ))}
-    </SpecQuestionList>
-  )
+  render() {
+    const {
+      questions,
+      layout,
+      additionalClass,
+      template,
+      currentWizardStep,
+      showHidden,
+      productTemplates,
+      productCategories,
+      isCreation,
+    } = this.props
+    const { skillOptions } = this.state
+
+    return (
+      <SpecQuestionList layout={layout} additionalClass={additionalClass}>
+        {questions.map(question => ({
+          ...question,
+          visibilityForRendering: isCreation ? getVisibilityForRendering(template, question, currentWizardStep) : STEP_VISIBILITY.READ_OPTIMIZED,
+          stepState: isCreation ? geStepState(question, currentWizardStep) : STEP_STATE.PREV
+        })).filter((question) =>
+          // hide if we are in a wizard mode and question is hidden for now
+          (question.visibilityForRendering !== STEP_VISIBILITY.NONE) &&
+          // hide if question is hidden by condition
+          (!_.get(question, '__wizard.hiddenByCondition')) &&
+          // hide hidden questions, unless we not force to show them
+          (showHidden || !question.hidden) &&
+          // hide question in edit mode if configured
+          (isCreation || !question.hiddenOnEdit)
+        ).map((q, index) => {
+          return  (
+            _.includes(['checkbox-group', 'radio-group', 'add-ons', 'textinput', 'textbox', 'numberinput', 'skills'], q.type) && q.visibilityForRendering === STEP_VISIBILITY.READ_OPTIMIZED ? (
+              <Accordion
+                key={q.fieldName || `accordion-${index}`}
+                title={q.summaryTitle || q.title}
+                type={q.type}
+                options={q.options || skillOptions || buildAddonsOptions(q, productTemplates, productCategories)}
+              >
+                {this.renderQ(q, index)}
+              </Accordion>
+            ) : (
+              this.renderQ(q, index)
+            )
+          )
+        })}
+      </SpecQuestionList>
+    )
+  }
 }
 
 SpecQuestions.propTypes = {


### PR DESCRIPTION
This PR contains changes to the skills question component:
- load skills from API
- cache skills to avoid reloading on each re-mounting
- ability to enter custom non-existent skills in the select