### PR TITLE
Product templates use sections

### DIFF
--- a/src/projects/detail/components/ProjectStage.jsx
+++ b/src/projects/detail/components/ProjectStage.jsx
@@ -196,7 +196,7 @@ class ProjectStage extends React.Component{
     const product = _.get(phase, 'products[0]')
     const productNonDirty = _.get(phaseNonDirty, 'products[0]')
     const template = {
-      sections: _.get(productTemplate, 'template.questions', [])
+      sections: _.get(productTemplate, 'template.sections', [])
     }
     const projectPhaseAnchor = `phase-${phase.id}-posts`
 

--- a/src/projects/detail/components/ProjectStage.jsx
+++ b/src/projects/detail/components/ProjectStage.jsx
@@ -195,9 +195,7 @@ class ProjectStage extends React.Component{
     const productTemplate = _.find(productTemplates, { id: _.get(phase, 'products[0].templateId') })
     const product = _.get(phase, 'products[0]')
     const productNonDirty = _.get(phaseNonDirty, 'products[0]')
-    const template = {
-      sections: _.get(productTemplate, 'template.sections', [])
-    }
+    const template = productTemplate.template
     const projectPhaseAnchor = `phase-${phase.id}-posts`
 
     const attachmentsStorePath = `${PROJECT_ATTACHMENTS_FOLDER}/${project.id}/phases/${phase.id}/products/${product.id}`
@@ -209,7 +207,7 @@ class ProjectStage extends React.Component{
     const unreadPostNotifications = filterNotificationsByPosts(unreadNotification, _.get(feed, 'posts', []))
     const unreadTimelineNotifications = timeline ? filterNotificationsByCriteria(unreadNotification, buildPhaseTimelineNotificationsCriteria(timeline)) : []
     const unreadSpecificationNotifications = filterNotificationsByCriteria(unreadNotification, buildPhaseSpecifiationNotificationsCriteria(phase))
-    
+
     const hasNotifications = {
       timeline: unreadTimelineNotifications.length > 0,
       posts: unreadPostNotifications.length > 0,

--- a/src/projects/detail/containers/SpecificationContainer.jsx
+++ b/src/projects/detail/containers/SpecificationContainer.jsx
@@ -12,10 +12,9 @@ import { getProjectProductTemplates } from '../../../helpers/templates'
 
 const SpecificationContainer = (props) => {
   // as for old projects we use productTemplate instead of projectTemplate
-  // it has `questions` property instead of `sections`
   // so we normalize template scheme for other components here
-  const template = _.omit(props.productTemplates[0].template, 'questions')
-  template.sections = props.productTemplates[0].template.questions
+  const template = _.omit(props.productTemplates[0].template, 'sections')
+  template.sections = props.productTemplates[0].template.sections
 
   return (
     <ScopeAndSpecificationContainer

--- a/src/projects/detail/containers/SpecificationContainer.jsx
+++ b/src/projects/detail/containers/SpecificationContainer.jsx
@@ -11,10 +11,12 @@ import ScopeAndSpecificationContainer from './ScopeAndSpecificationContainer'
 import { getProjectProductTemplates } from '../../../helpers/templates'
 
 const SpecificationContainer = (props) => {
-  // as for old projects we use productTemplate instead of projectTemplate
-  // so we normalize template scheme for other components here
-  const template = _.omit(props.productTemplates[0].template, 'sections')
-  template.sections = props.productTemplates[0].template.sections
+  if (!props.productTemplates || !props.productTemplates[0]) {
+    return null
+  }
+
+  // for old projects we use productTemplate instead of projectTemplate
+  const template = props.productTemplates[0].template
 
   return (
     <ScopeAndSpecificationContainer

--- a/src/routes/metadata/components/MetaDataPanel.jsx
+++ b/src/routes/metadata/components/MetaDataPanel.jsx
@@ -590,12 +590,6 @@ class MetaDataPanel extends React.Component {
   renderProductPreview({ template }) {
     const { templates, previewProject } = this.props
 
-    // we normalize it for the EditProjectForm component
-    const normalizedTemplate = {
-      ..._.omit(template, 'sections'),
-      sections: template.sections
-    }
-
     return (
       <div className="content template-preview">
         <div className="header">
@@ -605,7 +599,7 @@ class MetaDataPanel extends React.Component {
           shouldUpdateTemplate
           project={previewProject}
           saving={false}
-          template={normalizedTemplate}
+          template={template}
           productTemplates={templates.productTemplates}
           productCategories={templates.productCategories}
           isEdittable

--- a/src/routes/metadata/components/MetaDataPanel.jsx
+++ b/src/routes/metadata/components/MetaDataPanel.jsx
@@ -265,7 +265,7 @@ class MetaDataPanel extends React.Component {
         return { scope: { sections: sectionsDefaultValue }, phases: phasesDefaultValue }
       }
       if (metadataType === 'productTemplate') {
-        return { template: { questions: sectionsDefaultValue } }
+        return { template: { sections: sectionsDefaultValue } }
       }
       if (metadataType === 'projectType') {
         return { metadata: {} }
@@ -590,11 +590,10 @@ class MetaDataPanel extends React.Component {
   renderProductPreview({ template }) {
     const { templates, previewProject } = this.props
 
-    // as productTemplate's template has `questions` root element instead of `sections`
     // we normalize it for the EditProjectForm component
     const normalizedTemplate = {
-      ..._.omit(template, 'questions'),
-      sections: template.questions
+      ..._.omit(template, 'sections'),
+      sections: template.sections
     }
 
     return (


### PR DESCRIPTION
Product templates use `sections` instead of `questions`.

This PR can be merged after migration script is run to the Project Service https://github.com/topcoder-platform/tc-project-service/pull/317

Issue https://github.com/appirio-tech/connect-app/issues/3107

winning submission from challenge 30093923 - Topcoder Connect - Product template update