### PR TITLE
Fixing the version of draft-js as the latest release is causing troubles with connect’s message rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "brace": "^0.11.1",
     "classnames": "^2.2.3",
     "coffeescript": "^1.12.7",
-    "draft-js": "^0.10.1",
+    "draft-js": "0.10.5",
     "draft-js-drag-n-drop-plugin": "^2.0.0-rc2",
     "draft-js-image-plugin": "^2.0.0-rc2",
     "draft-js-mention-plugin": "^2.0.0-rc2",


### PR DESCRIPTION
draft-js library update causing too many errors with `convertFromRaw` method calls for `Cannot read property 'length' of undefined`