### PR TITLE
Hotfix/post release 2.4.13.6 

### DIFF
--- a/src/projects/detail/containers/DashboardContainer.jsx
+++ b/src/projects/detail/containers/DashboardContainer.jsx
@@ -8,7 +8,6 @@ import React from 'react'
 import _ from 'lodash'
 import { connect } from 'react-redux'
 import { withRouter, Link } from 'react-router-dom'
-import Alert from 'react-s-alert'
 import './DashboardContainer.scss'
 
 import {

--- a/src/projects/detail/containers/DashboardContainer.jsx
+++ b/src/projects/detail/containers/DashboardContainer.jsx
@@ -7,7 +7,7 @@
 import React from 'react'
 import _ from 'lodash'
 import { connect } from 'react-redux'
-import { Redirect, withRouter, Link } from 'react-router-dom'
+import { withRouter, Link } from 'react-router-dom'
 import Alert from 'react-s-alert'
 import './DashboardContainer.scss'
 
@@ -70,14 +70,9 @@ class DashboardContainer extends React.Component {
 
     this.state = {
       open: false,
-      matchesTopicUrl: null,
-      matchesPostUrl: null,
-      topicIdForPost: null
     }
     this.onNotificationRead = this.onNotificationRead.bind(this)
     this.toggleDrawer = this.toggleDrawer.bind(this)
-
-    this.alertedFailedTopicRedirect = false
   }
 
   onNotificationRead(notification) {
@@ -101,18 +96,6 @@ class DashboardContainer extends React.Component {
       })
     }
 
-    /*
-    For redirecting old urls to new urls for topics and posts
-    Old TOPIC: '/projects/{{projectId}}/#feed-{{topicId}}',
-    Old POST: '/projects/{{projectId}}/#comment-{{postId}}',
-    */
-    const matchesTopicUrl = location.hash.match(/#feed-(\d+)/)
-    const matchesPostUrl = location.hash.match(/#comment-(\d+)/)
-    this.setState({
-      matchesPostUrl,
-      matchesTopicUrl
-    })
-
     // if the user is a customer and its not a direct link to a particular phase
     // then by default expand all phases which are active
     if (_.isEmpty(location.hash) && this.props.isCustomerUser) {
@@ -130,38 +113,10 @@ class DashboardContainer extends React.Component {
     collapseAllProjectPhases()
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { isFeedsLoading } = nextProps
-    const { matchesPostUrl } = this.state
-
-    // we need topicId for redirecting old post url (/projects/{{projectId}}/#comment-{{postId}})
-    if (!isFeedsLoading && matchesPostUrl && !this.alertedFailedTopicRedirect) {
-      const topicIdForPost = this.getTopicIdForPost(matchesPostUrl[1])
-      this.setState({ topicIdForPost })
-      this.alertFailedTopicRedirection(matchesPostUrl, topicIdForPost, isFeedsLoading)
-    }
-  }
-
   toggleDrawer() {
     this.setState((prevState) => ({
       open: !prevState.open
     }))
-  }
-
-  // Get topic id corresponding to the post that we're trying to redirect to
-  getTopicIdForPost(postId) {
-    const {feeds} = this.props
-    const topic = feeds && feeds
-      .find(feed => feed.posts.find(p => p.id === Number(postId)))
-    return topic && topic.id
-  }
-
-  // Alert user in case the post is not available / not accessible to him.
-  alertFailedTopicRedirection(matchesPostUrl, topicIdForPost, isFeedsLoading) {
-    if (matchesPostUrl && !topicIdForPost && !isFeedsLoading) {
-      this.alertedFailedTopicRedirect = true
-      Alert.error('Couldn\'t find the post')
-    }
   }
 
   render() {
@@ -191,9 +146,6 @@ class DashboardContainer extends React.Component {
       location,
       estimationQuestion,
     } = this.props
-    const { matchesPostUrl, matchesTopicUrl, topicIdForPost } = this.state
-
-
     const projectTemplate = project && project.templateId && projectTemplates ? (getProjectTemplateById(projectTemplates, project.templateId)) : null
 
     let template
@@ -253,9 +205,6 @@ class DashboardContainer extends React.Component {
             { eventType: EVENT_TYPE.PROJECT_PLAN.PROGRESS_UPDATED, contents: { projectId: project.id } },
           ]}
         />
-
-        {matchesTopicUrl && <Redirect to={`/projects/${project.id}/messages/${matchesTopicUrl[1]}`} />}
-        {matchesPostUrl && topicIdForPost && <Redirect to={`/projects/${project.id}/messages/${topicIdForPost}#comment-${matchesPostUrl[1]}`}  />}
 
         <TwoColsLayout.Sidebar>
           <MediaQuery minWidth={SCREEN_BREAKPOINT_MD}>

--- a/src/projects/routes.jsx
+++ b/src/projects/routes.jsx
@@ -21,7 +21,26 @@ const FileDownloadWithAuth = requiresAuthentication(FileDownload)
 
 const ProjectDetailWithAuth = requiresAuthentication(() =>
   (<Switch>
-    <Route exact path="/projects/:projectId" render={() => <ProjectDetail component={Dashboard} />} />
+    <Route
+      exact
+      path="/projects/:projectId"
+      render={({ match, location }) => {
+        const matchesTopicUrl = location.hash.match(/#feed-(\d+)/)
+        const matchesPostUrl = location.hash.match(/#comment-(\d+)/)
+
+        // redirect old Topic URLs to the topics on the messages tab
+        if (matchesTopicUrl) {
+          return <Redirect to={`/projects/${match.params.projectId}/messages/${matchesTopicUrl[1]}`} />
+
+        // redirect old Posts URLs to the messages tab
+        // as we don't know the topic ID form the URL, message tab should take care about it
+        } else if (matchesPostUrl) {
+          return <Redirect to={`/projects/${match.params.projectId}/messages${location.hash}`} />
+        }
+
+        return <ProjectDetail component={Dashboard} />
+      }}
+    />
     <Route path="/projects/:projectId/status/:statusId" render={() => <ProjectDetail component={Dashboard} />} />
     <Route path="/projects/:projectId/messages/:topicId" render={() => <ProjectDetail component={MessagesTabContainer} />} />
     <Route path="/projects/:projectId/messages" render={() => <ProjectDetail component={MessagesTabContainer} />} />


### PR DESCRIPTION
Fix redirecting old URLs to the comments https://connect.topcoder.com/projects/1234#comment-1234456789 to the new messages tab https://connect.topcoder.com/projects/1234/messages/12345#comment-1234456789

Fix also, containing a fix for more general issue `isLoading` didn't represent loading status of topics correctly, as we loaded two kind of topics in parallel, and soon as one type of topics was loaded `isLoading` became `false` though another type of topics may be still loading.

Also, fix refactors approach for handling redirecting topics:
- we don't load Dashboard container just to redirect to the message tab, redirecting happens before loading Dashboard container.
- redirecting is processed inside Messages tab container as that container should be responsible for loading topics in the future.