### PR TITLE
Fix for issue #3215

### DIFF
--- a/src/components/SelectDropdown/SelectDropdown.jsx
+++ b/src/components/SelectDropdown/SelectDropdown.jsx
@@ -113,7 +113,7 @@ class SelectDropdown extends Component {
         </li>
       )
       return option.toolTipMessage ? (
-        <Tooltip theme="light" tooltipDelay={TOOLTIP_DEFAULT_DELAY} key={optIdx}>
+        <Tooltip theme="light" tooltipDelay={TOOLTIP_DEFAULT_DELAY} key={optIdx} usePortal={true}>
           <div className="tooltip-target">
             {selectItem}
           </div>


### PR DESCRIPTION
#3215 

Add usePortal=true flag to the tooltip in dropdown's option to indicate that the tooltip body will be appended to the body of DOM instead of the target.

react-portal is added in https://github.com/appirio-tech/react-components/pull/335