### PR TITLE
[Hotfix] [PROD] post release 2.4.15.3

### DIFF
--- a/src/components/AuthenticatedComponent.jsx
+++ b/src/components/AuthenticatedComponent.jsx
@@ -22,8 +22,8 @@ export function requiresAuthentication(Component) {
         this.setState({isLoggedIn: true})
       }).catch((error) => {
         console.log(error)
-        // FIXME should we include hash, search etc
-        const redirectBackToUrl = window.location.origin + this.props.location.pathname
+        // we have to to redirect to the same page, so we use the whole URL
+        const redirectBackToUrl = encodeURIComponent(window.location.href)
         const newLocation = ACCOUNTS_APP_LOGIN_URL + '?retUrl=' + redirectBackToUrl
         console.log('redirecting... ', newLocation)
         window.location = newLocation


### PR DESCRIPTION
This hotfix contains a fix: keep the whole URL when redirecting after log-in. This is to support issue https://github.com/appirio-tech/connect-app/issues/3311.

When we navigate to any page being logged-out we are redirecting to login page. The same time we should keep the FULL URL which we have before so after login we can redirect back to the same page we were trying to navigate.

Before this fix we only keep a part of URL so sometimes we redirect back not to the exact page we were going to initially.