### PR TITLE
Fix for Issue #3472 Keep form data for the same template

### DIFF
--- a/src/projects/create/components/ProjectWizard.jsx
+++ b/src/projects/create/components/ProjectWizard.jsx
@@ -374,6 +374,9 @@ class ProjectWizard extends Component {
         newProject.name = { $set:_.get(incompleteProject, 'name') }
         newProject.description = { $set:_.get(incompleteProject, 'description') }
         newProject.details = { $set: { utm: { code:_.get(incompleteProject, 'details.utm.code') } } }
+      } else {
+        // retain previously filled data (if any) when choosing the same template
+        _.assign(newProject, { $merge : incompleteProject })
       }
     }
     window.scrollTo(0, 0)


### PR DESCRIPTION
#3472   

Retain previously filled wizard data (if any) when choosing the same template