### PR TITLE
[DEV] [HOTFIX] remove 2 roles from TaaS Intake Form

### DIFF
--- a/src/projects/detail/components/JobPickerRow/JobPickerRow.jsx
+++ b/src/projects/detail/components/JobPickerRow/JobPickerRow.jsx
@@ -46,9 +46,7 @@ class JobPickerRow extends React.PureComponent {
       { value: 'designer', title: 'Designer'},
       { value: 'software-developer', title: 'Software Developer'},
       { value: 'data-scientist', title: 'Data Scientist'},
-      { value: 'data-engineer', title: 'Data Engineer'},
-      { value: 'qa', title: 'QA Tester'},
-      { value: 'qa-engineer', title: 'QA Engineer'}
+      { value: 'data-engineer', title: 'Data Engineer'}
     ]
   }
   handleJobTitleChange(evt) {


### PR DESCRIPTION
 remove the following values from the Role dropdown: `QA Tester`  and `QA Engineer`
 
 Before:
 
![image](https://user-images.githubusercontent.com/146016/108870582-ec366f00-7600-11eb-9de6-8934d4954cec.png)
 
 After:
 
![image](https://user-images.githubusercontent.com/146016/108870506-d9239f00-7600-11eb-8a6c-56aba20d6b74.png)
