### PR TITLE
Fixing env variable reading for NDA Terms

### DIFF
--- a/src/projects/detail/components/NDAField/index.jsx
+++ b/src/projects/detail/components/NDAField/index.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 import { HOC as hoc } from 'formsy-react'
 import _ from 'lodash'
 import RadioGroup from 'appirio-tech-react-components/components/Formsy/RadioGroup'
-import { DEFAULT_NDA_UUID } from '../../../../../config/constants'
+import { DEFAULT_NDA_UUID } from '../../../../config/constants'
 
 class NDAField extends React.Component {
   constructor(props) {


### PR DESCRIPTION
reading from constants file in src folder instead of reading from root (which only works with circle ci)
We fixed it with https://github.com/appirio-tech/connect-app/pull/4290 but with refactoring after first milestone got it overridden.